### PR TITLE
Add specific link to Pattern class javadocs

### DIFF
--- a/content/api_en/match.xml
+++ b/content/api_en/match.xml
@@ -51,7 +51,7 @@ To use the function, first check to see if the result is null. If the result is 
 <br/>
 If there are groups (specified by sets of parentheses) in the regular expression, then the contents of each will be returned in the array. Element [0] of a regular expression match returns the entire matching string, and the match groups start at element [1] (the first group is [1], the second [2], and so on).<br/>
 <br/>
-The syntax can be found in the reference for Java's <a href="http://download.oracle.com/javase/6/docs/api/">Pattern</a> class. For regular expression syntax, read the <a href="http://download.oracle.com/javase/tutorial/essential/regex/">Java Tutorial</a> on the topic.
+The syntax can be found in the reference for Java's <a href="http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html">Pattern</a> class. For regular expression syntax, read the <a href="http://download.oracle.com/javase/tutorial/essential/regex/">Java Tutorial</a> on the topic.
 ]]></description>
 
 </root>

--- a/content/api_en/matchAll.xml
+++ b/content/api_en/matchAll.xml
@@ -33,7 +33,7 @@ To use the function, first check to see if the result is null. If the result is 
 <br/>
 If there are groups (specified by sets of parentheses) in the regular expression, then the contents of each will be returned in the array. Assuming a loop with counter variable i, element [i][0] of a regular expression match returns the entire matching string, and the match groups start at element [i][1] (the first group is [i][1], the second [i][2], and so on).<br/>
 <br/>
-The syntax can be found in the reference for Java's <a href="http://download.oracle.com/javase/6/docs/api/">Pattern</a> class. For regular expression syntax, read the <a href="http://download.oracle.com/javase/tutorial/essential/regex/">Java Tutorial</a> on the topic.
+The syntax can be found in the reference for Java's <a href="http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html">Pattern</a> class. For regular expression syntax, read the <a href="http://download.oracle.com/javase/tutorial/essential/regex/">Java Tutorial</a> on the topic.
 ]]></description>
 
 </root>


### PR DESCRIPTION
Fix #97

Replaces generic link by specific link to Pattern class in match() and matchAll() reference pages.
