### PR TITLE
Fix fields "name" and "category" in file "saveTable.xml"

### DIFF
--- a/content/api_en/saveTable.xml
+++ b/content/api_en/saveTable.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <root>
-<name>loadTable()</name>
+<name>saveTable()</name>
 
-<category>Input</category>
+<category>Output</category>
 
 <subcategory>Files</subcategory>
 


### PR DESCRIPTION
Hello,

The API XML documentation for the function "saveTable" had a few typos.
1. It said that the name of the function was "loadTable" instead of "saveTable".
2. It also said that the category of the function was "Input" instead of "Output" as it is in the [Processing reference](http://processing.org/reference/).

This commit fixes those two issues.
