### PR TITLE
Fix typos in Environment reference

### DIFF
--- a/content/api_en/environment/index.html
+++ b/content/api_en/environment/index.html
@@ -36,14 +36,14 @@
 		Sketches can draw two- and three-dimensional graphics. The default renderer is for drawing 
 		two-dimensional graphics. The P3D renderer makes it possible to draw three-dimensional graphics, 
 		which includes controlling the camera, lighting, and materials. 
-		The P2D renderer is a fast, but last accurate renderer for drawing two-dimensional graphics. Both the P2D and P3D 
+		The P2D renderer is a fast, but less accurate renderer for drawing two-dimensional graphics. Both the P2D and P3D 
 		renderers are accelerated if your computer has an OpenGL compatible graphics card.
     </p>  
        
 	<p>
 		The capabilities of Processing are extended with <em>Libraries</em> and <em>Tools</em>. 
 		Libraries make it possible for sketches to do things beyond the <em>core</em> 
-		Processing code. There are hundred of libraries contributed by the Processing community 
+		Processing code. There are hundreds of libraries contributed by the Processing community 
 		that can be added to your sketches to enable new things like playing sounds, doing computer 
 		vision, and working with advanced 3D geometry. Tools extend the PDE to help make creating 
 		sketches easier by providing interfaces for tasks like selecting colors.
@@ -251,13 +251,13 @@ Big-picture keywords / concepts for getting into Processing
     <li><em>Decrease Indent (Ctrl+[)</em><br />
       If the text is indented, removes two spaces from the indent.</li>
     <li><em>Find... (Ctrl+F)</em><br />
-      Finds an occurance of a text string within the file open in the text editor 
+      Finds an occurence of a text string within the file open in the text editor 
       and gives the option to replace it with a different text.</li>
     <li><em>Find Next (Ctrl+G)</em><br />
-      Finds the next occurance of a text string within the file open in the text 
+      Finds the next occurence of a text string within the file open in the text 
       editor.</li>
     <li><em>Find Previous (Shift+Ctrl+G)</em><br />
-      Finds the previous occurance of a text string within the file open in the text 
+      Finds the previous occurence of a text string within the file open in the text 
       editor.</li>
     <!--<li><em>Use Selection for Find</em><br /></li>-->
 	</ul>
@@ -396,7 +396,7 @@ Big-picture keywords / concepts for getting into Processing
 		Windows and Linux and in the Processing menu on Mac Os X. The full list of preferences 
 		are stored in the "preferences.txt" file. This file can be opened and edited directly 
 		only when Processing is not running. You can find the location of this file on your 
-		computer by reading the bottom-left corner of the Prefereces window.
+		computer by reading the bottom-left corner of the Preferences window.
     </p>
     
     <ul>
@@ -483,7 +483,7 @@ Big-picture keywords / concepts for getting into Processing
     
     <p>  
       The renderer used for each sketch is specified through the size() function. 
-      If a renderer is not explicity defined in size(), it uses the default renderer.
+      If a renderer is not explicitly defined in size(), it uses the default renderer.
       For example, the following program:
     </p>
     


### PR DESCRIPTION
Fixes several typos in the Environment reference.

Fixes issue #109
