### PR TITLE
Corrections to the Descriptions of rotateX(), rotateY() and rotateZ()

### DIFF
--- a/content/api_en/PShape_rotate.xml
+++ b/content/api_en/PShape_rotate.xml
@@ -31,9 +31,9 @@ void mousePressed() {
 </example>
 
 <description><![CDATA[
-Rotates a shape the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to TWO_PI) or converted to radians with the <b>radians()</b> method.
+Rotates a <b>PShape</b> object the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
 <br /><br />
-Shapes are always rotated around the upper-left corner of their bounding box. Positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens after and subsequent calls to the method accumulates the effect. For example, calling <b>rotate(HALF_PI)</b> and then <b>rotate(HALF_PI)</b> is the same as <b>rotate(PI)</b>. This transformation is applied directly to the shape, it's not refreshed each time <b>draw()</b> is run. 
+Objects are always rotated around the upper-left corner of their bounding box, and positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens afterward, and subsequent calls to the function accumulate the effect. For example, calling <b>rotate(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotate(PI)</b>. This transformation is applied directly to the object, it is not reset each time <b>draw()</b> is run.
 ]]></description>
 
 </root>

--- a/content/api_en/PShape_rotateX.xml
+++ b/content/api_en/PShape_rotateX.xml
@@ -31,11 +31,11 @@ void mousePressed() {
 </example>
 
 <description><![CDATA[
-Rotates a shape around the x-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to TWO_PI) or converted to radians with the <b>radians()</b> method.
+Rotates a <b>PShape</b> object around the x-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
 <br /><br />
-Shapes are always rotated around the upper-left corner of their bounding box. Positive numbers rotate objects in a clockwise direction. Subsequent calls to the method accumulates the effect. For example, calling <b>rotateX(HALF_PI)</b> and then <b>rotateX(HALF_PI)</b> is the same as <b>rotateX(PI)</b>. This transformation is applied directly to the shape, it's not refreshed each time <b>draw()</b> is run.  
+Objects are always rotated around the upper-left corner of their bounding box, and positive numbers rotate objects in a clockwise direction. Subsequent calls to the function accumulate the effect. For example, calling <b>rotateX(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotateX(PI)</b>. This transformation is applied directly to the object, it is not reset each time <b>draw()</b> is run.  
 <br /><br />
-This method requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
+This function requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
 ]]></description>
 
 </root>

--- a/content/api_en/PShape_rotateY.xml
+++ b/content/api_en/PShape_rotateY.xml
@@ -31,11 +31,11 @@ void mousePressed() {
 </example>
 
 <description><![CDATA[
-Rotates a shape around the y-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to TWO_PI) or converted to radians with the <b>radians()</b> method.
+Rotates a <b>PShape</b> object around the y-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
 <br /><br />
-Shapes are always rotated around the upper-left corner of their bounding box. Positive numbers rotate objects in a clockwise direction. Subsequent calls to the method accumulates the effect. For example, calling <b>rotateY(HALF_PI)</b> and then <b>rotateY(HALF_PI)</b> is the same as <b>rotateY(PI)</b>. This transformation is applied directly to the shape, it's not refreshed each time <b>draw()</b> is run. 
+Objects are always rotated around the upper-left corner of their bounding box, and positive numbers rotate objects in a clockwise direction. Subsequent calls to the function accumulate the effect. For example, calling <b>rotateY(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotateY(PI)</b>. This transformation is applied directly to the object, it is not reset each time <b>draw()</b> is run.
 <br /><br />
-This method requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
+This function requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
 ]]></description>
 
 </root>

--- a/content/api_en/PShape_rotateZ.xml
+++ b/content/api_en/PShape_rotateZ.xml
@@ -31,11 +31,11 @@ void mousePressed() {
 </example>
 
 <description><![CDATA[
-Rotates a shape around the z-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to TWO_PI) or converted to radians with the <b>radians()</b> method.
+Rotates a <b>PShape</b> object around the z-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
 <br /><br />
-Shapes are always rotated around the upper-left corner of their bounding box. Positive numbers rotate objects in a clockwise direction. Subsequent calls to the method accumulates the effect. For example, calling <b>rotateZ(HALF_PI)</b> and then <b>rotateZ(HALF_PI)</b> is the same as <b>rotateZ(PI)</b>. This transformation is applied directly to the shape, it's not refreshed each time <b>draw()</b> is run. 
+Objects are always rotated around the upper-left corner of their bounding box, and positive numbers rotate objects in a clockwise direction. Subsequent calls to the function accumulate the effect. For example, calling <b>rotateZ(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotateZ(PI)</b>. This transformation is applied directly to the object, it is not reset each time <b>draw()</b> is run. 
 <br /><br />
-This method requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
+This function requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
 ]]></description>
 
 </root>

--- a/content/api_en/rotate.xml
+++ b/content/api_en/rotate.xml
@@ -18,9 +18,9 @@ rect(-26, -26, 52, 52);
 </example>
 
 <description><![CDATA[
-Rotates a shape the amount specified by the <b>angle</b> parameter. Angles must be specified in radians (values from <b>0</b> to <b>TWO_PI</b>), or they can be converted from degrees to radians with the <b>radians()</b> function. 
+Rotates an object the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function. 
 <br/> <br/>
-Objects are always rotated around their relative position to the origin, and positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens afterward, and subsequent calls to the function compound the effect. For example, calling <b>rotate(HALF_PI)</b> once and then calling <b>rotate(HALF_PI)</b> a second time is the same as a single <b>rotate(PI)</b>. All tranformations are reset when <b>draw()</b> begins again. 
+Objects are always rotated around their relative position to the origin, and positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens afterward, and subsequent calls to the function accumulate the effect. For example, calling <b>rotate(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotate(PI)</b>. If <b>rotate()</b> is called within <b>draw()</b>, the transformation is reset when the loop begins again.
 <br/> <br/>
 Technically, <b>rotate()</b> multiplies the current transformation matrix by a rotation matrix. This function can be further controlled by <b>pushMatrix()</b> and <b>popMatrix()</b>.
 ]]></description>

--- a/content/api_en/rotateX.xml
+++ b/content/api_en/rotateX.xml
@@ -29,7 +29,11 @@ rect(-26, -26, 52, 52);
 </example>
 
 <description><![CDATA[
-Rotates a shape around the x-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to PI*2) or converted to radians with the <b>radians()</b> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a counterclockwise direction. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <b>rotateX(PI/2)</b> and then <b>rotateX(PI/2)</b> is the same as <b>rotateX(PI)</b>. If <b>rotateX()</b> is called within the <b>draw()</b>, the transformation is reset when the loop begins again. This function requires using P3D as a third parameter to <b>size()</b> as shown in the example above. 
+Rotates an object around the x-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
+<br /><br />
+Objects are always rotated around their relative position to the origin, and positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens afterward and subsequent calls to the function accumulate the effect. For example, calling <b>rotateX(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotateX(PI)</b>. If <b>rotateX()</b> is called within <b>draw()</b>, the transformation is reset when the loop begins again.
+<br /><br />
+This function requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
 ]]></description>
 
 </root>

--- a/content/api_en/rotateY.xml
+++ b/content/api_en/rotateY.xml
@@ -29,7 +29,11 @@ rect(-26, -26, 52, 52);
 </example>
 
 <description><![CDATA[
-Rotates a shape around the y-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to PI*2) or converted to radians with the <b>radians()</b> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a counterclockwise direction. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <b>rotateY(PI/2)</b> and then <b>rotateY(PI/2)</b> is the same as <b>rotateY(PI)</b>. If <b>rotateY()</b> is called within the <b>draw()</b>, the transformation is reset when the loop begins again. This function requires using P3D as a third parameter to <b>size()</b> as shown in the examples above. 
+Rotates an object around the y-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
+<br /><br />
+Objects are always rotated around their relative position to the origin, and positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens afterward and subsequent calls to the function accumulate the effect. For example, calling <b>rotateY(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotateY(PI)</b>. If <b>rotateY()</b> is called within <b>draw()</b>, the transformation is reset when the loop begins again.
+<br /><br />
+This function requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
 ]]></description>
 
 </root>

--- a/content/api_en/rotateZ.xml
+++ b/content/api_en/rotateZ.xml
@@ -29,7 +29,11 @@ rect(-26, -26, 52, 52);
 </example>
 
 <description><![CDATA[
-Rotates a shape around the z-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from 0 to PI*2) or converted to radians with the <b>radians()</b> function. Objects are always rotated around their relative position to the origin and positive numbers rotate objects in a counterclockwise direction. Transformations apply to everything that happens after and subsequent calls to the function accumulates the effect. For example, calling <b>rotateZ(PI/2)</b> and then <b>rotateZ(PI/2)</b> is the same as <b>rotateZ(PI)</b>. If <b>rotateZ()</b> is called within the <b>draw()</b>, the transformation is reset when the loop begins again. This function requires using P3D as a third parameter to <b>size()</b> as shown in the examples above. 
+Rotates an object around the z-axis the amount specified by the <b>angle</b> parameter. Angles should be specified in radians (values from <b>0</b> to <b>TWO_PI</b>) or converted from degrees with the <b>radians()</b> function.
+<br /><br />
+Objects are always rotated around their relative position to the origin, and positive numbers rotate objects in a clockwise direction. Transformations apply to everything that happens afterward and subsequent calls to the function accumulate the effect. For example, calling <b>rotateZ(HALF_PI)</b> once and then calling it a second time is the same as a single <b>rotateZ(PI)</b>. If <b>rotateZ()</b> is called within <b>draw()</b>, the transformation is reset when the loop begins again.
+<br /><br />
+This function requires a 3D renderer. You need to use P3D as a third parameter for the <b>size()</b> function as shown in the example above.
 ]]></description>
 
 </root>


### PR DESCRIPTION
As raised in issue #219, contrary to what the descriptions of the these functions say, positive numbers actually rotate objects in a CLOCKWISE direction. This pull request is to correct these errors by reversing the direction mentioned in the description of each of these functions. 

Furthermore, inconsistent wording (e.g. "function" vs "method", "reset" vs "refresh", "accumulate" vs "compound") and formatting choices (e.g. "TWO_PI" vs "PI*2", font, paragraphing) used in the descriptions of different rotation-related functions (i.e PShape.rotate(), PShape.rotateX(), PShape.rotateY(), PShape.rotateZ(), rotate(), rotateX(), rotateY() and rotateZ()) are now made uniform across these documents.