### PR TITLE
Update wiggling example

### DIFF
--- a/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
+++ b/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
@@ -149,15 +149,15 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
+  face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
+  face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
+  face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
+  face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
     float x = circleRad * sin(angle);
-    float y = +cubeSize/2;
+    float y = -cubeSize/2;
     float z = circleRad * cos(angle);
     face.vertex(x, y, z);
   }
@@ -170,15 +170,15 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
+  face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
+  face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
+  face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
+  face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
     float x = circleRad * sin(angle);
-    float y = -cubeSize/2;
+    float y = +cubeSize/2;
     float z = circleRad * cos(angle);
     face.vertex(x, y, z);
   }
@@ -248,20 +248,6 @@ void restoreCube() {
 
   // Top face
   face = cube.getChild(4);
-  face.setVertex(0, -cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.setVertex(1, +cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.setVertex(2, +cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.setVertex(3, -cubeSize/2, +cubeSize/2, -cubeSize/2);
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
-    float y = +cubeSize/2;
-    float z = circleRad * cos(angle);
-    face.setVertex(4 + i, x, y, z);
-  }    
-
-  // Bottom face
-  face = cube.getChild(5);
   face.setVertex(0, +cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.setVertex(1, -cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.setVertex(2, -cubeSize/2, -cubeSize/2, -cubeSize/2);
@@ -270,6 +256,20 @@ void restoreCube() {
     float angle = TWO_PI * i / circleRes;
     float x = circleRad * sin(angle);
     float y = -cubeSize/2;
+    float z = circleRad * cos(angle);
+    face.setVertex(4 + i, x, y, z);
+  }    
+
+  // Bottom face
+  face = cube.getChild(5);
+  face.setVertex(0, -cubeSize/2, +cubeSize/2, +cubeSize/2);
+  face.setVertex(1, +cubeSize/2, +cubeSize/2, +cubeSize/2);
+  face.setVertex(2, +cubeSize/2, +cubeSize/2, -cubeSize/2);
+  face.setVertex(3, -cubeSize/2, +cubeSize/2, -cubeSize/2);
+  for (int i = 0; i < circleRes; i++) {
+    float angle = TWO_PI * i / circleRes;
+    float x = circleRad * sin(angle);
+    float y = +cubeSize/2;
     float z = circleRad * cos(angle);
     face.setVertex(4 + i, x, y, z);
   }

--- a/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
+++ b/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
@@ -65,12 +65,10 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.beginContour();
   face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
   face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.endContour();
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -88,12 +86,10 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.beginContour();
   face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
   face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
   face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.endContour();
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -111,12 +107,10 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.beginContour();
   face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.endContour();
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -134,12 +128,10 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.beginContour();
   face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
   face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
   face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.endContour();
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -157,12 +149,10 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.beginContour();
   face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
   face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.endContour();
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -180,12 +170,10 @@ void createCube() {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
-  face.beginContour();
   face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
   face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.endContour();
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -286,4 +274,3 @@ void restoreCube() {
     face.setVertex(4 + i, x, y, z);
   }
 }
-

--- a/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
+++ b/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
@@ -38,7 +38,7 @@ void draw() {
     }
   }
 
-  println(frameRate);
+  if (frameCount % 60 == 0) println(frameRate);
 }
 
 public void keyPressed() {
@@ -60,15 +60,51 @@ void createCube() {
 
   PShape face;
 
-  // Front face         
-  face = createShape();
+  // Create all faces at front position
+  for (int i = 0; i < 6; i++) {
+    face = createShape();
+    createFaceWithHole(face);
+    cube.addChild(face);
+  }
+
+  // Rotate all the faces to their positions
+
+  // Front face - already correct
+  face = cube.getChild(0);
+
+  // Back face
+  face = cube.getChild(1);
+  face.rotateY(radians(180));
+
+  // Right face
+  face = cube.getChild(2);
+  face.rotateY(radians(90));
+
+  // Left face
+  face = cube.getChild(3);
+  face.rotateY(radians(-90));
+
+  // Top face
+  face = cube.getChild(4);
+  face.rotateX(radians(90));
+
+  // Bottom face
+  face = cube.getChild(5);
+  face.rotateX(radians(-90));
+}
+
+void createFaceWithHole(PShape face) {
   face.beginShape(POLYGON);
   face.stroke(255, 0, 0);
   face.fill(255);
+
+  // Draw main shape Clockwise
   face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
+  face.vertex(-cubeSize / 2, +cubeSize / 2, +cubeSize / 2);
+
+  // Draw contour (hole) Counter-Clockwise
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
@@ -78,120 +114,21 @@ void createCube() {
     face.vertex(x, y, z);
   }
   face.endContour();
-  face.endShape(CLOSE);
-  cube.addChild(face);
 
-  // Back face
-  face = createShape();
-  face.beginShape(POLYGON);
-  face.stroke(255, 0, 0);
-  face.fill(255);
-  face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.beginContour();
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = -circleRad * sin(angle);
-    float y = circleRad * cos(angle);
-    float z = -cubeSize/2;
-    face.vertex(x, y, z);
-  }
-  face.endContour();
   face.endShape(CLOSE);
-  cube.addChild(face);
-
-  // Right face
-  face = createShape();
-  face.beginShape(POLYGON);
-  face.stroke(255, 0, 0);
-  face.fill(255);
-  face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.beginContour();
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = +cubeSize/2;
-    float y = circleRad * sin(angle);
-    float z = circleRad * cos(angle);
-    face.vertex(x, y, z);
-  }
-  face.endContour();
-  face.endShape(CLOSE);
-  cube.addChild(face);
-
-  // Left face
-  face = createShape();
-  face.beginShape(POLYGON);
-  face.stroke(255, 0, 0);
-  face.fill(255);
-  face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.beginContour();
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = -cubeSize/2;
-    float y = circleRad * sin(angle);
-    float z = -circleRad * cos(angle);
-    face.vertex(x, y, z);
-  }
-  face.endContour();
-  face.endShape(CLOSE);
-  cube.addChild(face);
-
-  // Top face
-  face = createShape();
-  face.beginShape(POLYGON);
-  face.stroke(255, 0, 0);
-  face.fill(255);
-  face.vertex(+cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.vertex(-cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.vertex(+cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.beginContour();
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
-    float y = -cubeSize/2;
-    float z = circleRad * cos(angle);
-    face.vertex(x, y, z);
-  }
-  face.endContour();
-  face.endShape(CLOSE);
-  cube.addChild(face);     
-
-  // Bottom face
-  face = createShape();
-  face.beginShape(POLYGON);
-  face.stroke(255, 0, 0);
-  face.fill(255);
-  face.vertex(-cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.vertex(+cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.vertex(-cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.beginContour();
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = -circleRad * sin(angle);
-    float y = +cubeSize/2;
-    float z = circleRad * cos(angle);
-    face.vertex(x, y, z);
-  }
-  face.endContour();
-  face.endShape(CLOSE);
-  cube.addChild(face);
 }
 
 void restoreCube() {
-  PShape face;
+  // Rotation of faces is preserved, so we just reset them
+  // the same way as the "front" face and they will stay
+  // rotated correctly
+  for (int i = 0; i < 6; i++) {
+    PShape face = cube.getChild(i);
+    restoreFaceWithHole(face);
+  }
+}
 
-  // Front face
-  face = cube.getChild(0);
+void restoreFaceWithHole(PShape face) {
   face.setVertex(0, -cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.setVertex(1, +cubeSize/2, -cubeSize/2, +cubeSize/2);
   face.setVertex(2, +cubeSize/2, +cubeSize/2, +cubeSize/2);
@@ -201,76 +138,6 @@ void restoreCube() {
     float x = circleRad * sin(angle);
     float y = circleRad * cos(angle);
     float z = +cubeSize/2;
-    face.setVertex(4 + i, x, y, z);
-  }
-
-  // Back face
-  face = cube.getChild(1);
-  face.setVertex(0, +cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.setVertex(1, -cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.setVertex(2, -cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.setVertex(3, +cubeSize/2, +cubeSize/2, -cubeSize/2);
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = -circleRad * sin(angle);
-    float y = circleRad * cos(angle);
-    float z = -cubeSize/2;
-    face.setVertex(4 + i, x, y, z);
-  }
-
-  // Right face
-  face = cube.getChild(2);
-  face.setVertex(0, +cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.setVertex(1, +cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.setVertex(2, +cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.setVertex(3, +cubeSize/2, +cubeSize/2, +cubeSize/2);
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = +cubeSize/2;
-    float y = circleRad * sin(angle);
-    float z = circleRad * cos(angle);
-    face.setVertex(4 + i, x, y, z);
-  }
-
-  // Left face
-  face = cube.getChild(3);
-  face.setVertex(0, -cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.setVertex(1, -cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.setVertex(2, -cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.setVertex(3, -cubeSize/2, +cubeSize/2, -cubeSize/2);
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = -cubeSize/2;
-    float y = circleRad * sin(angle);
-    float z = -circleRad * cos(angle);
-    face.setVertex(4 + i, x, y, z);
-  }    
-
-  // Top face
-  face = cube.getChild(4);
-  face.setVertex(0, +cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.setVertex(1, -cubeSize/2, -cubeSize/2, +cubeSize/2);
-  face.setVertex(2, -cubeSize/2, -cubeSize/2, -cubeSize/2);
-  face.setVertex(3, +cubeSize/2, -cubeSize/2, -cubeSize/2);
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
-    float y = -cubeSize/2;
-    float z = circleRad * cos(angle);
-    face.setVertex(4 + i, x, y, z);
-  }    
-
-  // Bottom face
-  face = cube.getChild(5);
-  face.setVertex(0, -cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.setVertex(1, +cubeSize/2, +cubeSize/2, +cubeSize/2);
-  face.setVertex(2, +cubeSize/2, +cubeSize/2, -cubeSize/2);
-  face.setVertex(3, -cubeSize/2, +cubeSize/2, -cubeSize/2);
-  for (int i = 0; i < circleRes; i++) {
-    float angle = TWO_PI * i / circleRes;
-    float x = -circleRad * sin(angle);
-    float y = +cubeSize/2;
-    float z = circleRad * cos(angle);
     face.setVertex(4 + i, x, y, z);
   }
 }

--- a/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
+++ b/content/examples/Demos/Graphics/Wiggling/Wiggling.pde
@@ -93,7 +93,7 @@ void createCube() {
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
+    float x = -circleRad * sin(angle);
     float y = circleRad * cos(angle);
     float z = -cubeSize/2;
     face.vertex(x, y, z);
@@ -137,7 +137,7 @@ void createCube() {
     float angle = TWO_PI * i / circleRes;
     float x = -cubeSize/2;
     float y = circleRad * sin(angle);
-    float z = circleRad * cos(angle);
+    float z = -circleRad * cos(angle);
     face.vertex(x, y, z);
   }
   face.endContour();
@@ -177,7 +177,7 @@ void createCube() {
   face.beginContour();
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
+    float x = -circleRad * sin(angle);
     float y = +cubeSize/2;
     float z = circleRad * cos(angle);
     face.vertex(x, y, z);
@@ -212,7 +212,7 @@ void restoreCube() {
   face.setVertex(3, +cubeSize/2, +cubeSize/2, -cubeSize/2);
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
+    float x = -circleRad * sin(angle);
     float y = circleRad * cos(angle);
     float z = -cubeSize/2;
     face.setVertex(4 + i, x, y, z);
@@ -242,7 +242,7 @@ void restoreCube() {
     float angle = TWO_PI * i / circleRes;
     float x = -cubeSize/2;
     float y = circleRad * sin(angle);
-    float z = circleRad * cos(angle);
+    float z = -circleRad * cos(angle);
     face.setVertex(4 + i, x, y, z);
   }    
 
@@ -268,7 +268,7 @@ void restoreCube() {
   face.setVertex(3, -cubeSize/2, +cubeSize/2, -cubeSize/2);
   for (int i = 0; i < circleRes; i++) {
     float angle = TWO_PI * i / circleRes;
-    float x = circleRad * sin(angle);
+    float x = -circleRad * sin(angle);
     float y = +cubeSize/2;
     float z = circleRad * cos(angle);
     face.setVertex(4 + i, x, y, z);


### PR DESCRIPTION
Following up on https://github.com/processing/processing/issues/3550

First three commits fix issues:
- begin/endContour() should be called after drawing the main shape
- contours should be drawn counterclockwise, otherwise they won't make a hole
- top and bottom faces were swapped

Last commit simplifies the code by moving face creation and restoration into a separate function and uses rotating faces to their position. If it goes against the purpose of the example, just revert that one.