### PR TITLE
Array Tutorial: Remove lingering book annotations from page.

### DIFF
--- a/content/static/tutorials/arrays/index.html
+++ b/content/static/tutorials/arrays/index.html
@@ -712,13 +712,6 @@ void draw() {
     rings[i].display();
   }
 }
-28-24
-9236_028.indd 426 10/16/2014 8:
-43:
-18 PM
-PROPERTY OF THE MIT PRESS
-FOR PROOFREADING, INDEXING, AND PROMOTIONAL PURPOSES ONLY
-427 Arrays
 // Click to create a new Ring
 void mousePressed() {
   rings[currentRing].start(mouseX, mouseY);


### PR DESCRIPTION
The following text has been removed from some source code toward the end of the tutorial:

28-24
9236_028.indd 426 10/16/2014 8:
43:
18 PM
PROPERTY OF THE MIT PRESS
FOR PROOFREADING, INDEXING, AND PROMOTIONAL PURPOSES ONLY
427 Arrays

