### PR TITLE
Typo fix on coordinate system tutorial... x and y axes text on 'Eighth Grade' coordinate example

### DIFF
--- a/content/static/tutorials/drawing/imgs/drawing-03.svg
+++ b/content/static/tutorials/drawing/imgs/drawing-03.svg
@@ -19,8 +19,8 @@
 		<line fill="none" stroke="#999999" stroke-width="1.3" x1="-9.6" y1="241.7" x2="-9.6" y2="561.6"/>
 		<line fill="none" stroke="#999999" stroke-width="1.3" x1="-62.8" y1="241.7" x2="-62.8" y2="561.6"/>
 	</g>
-	<text transform="matrix(1 0 0 1 35.374 222.8224)" font-family="'TheSerif-HP5Plain'" font-size="25.8187">x</text>
-	<text transform="matrix(1 0 0 1 216.0039 404.6212)" font-family="'TheSerif-HP5Plain'" font-size="25.8187">y</text>
+	<text transform="matrix(1 0 0 1 35.374 222.8224)" font-family="'TheSerif-HP5Plain'" font-size="25.8187">y</text>
+	<text transform="matrix(1 0 0 1 216.0039 404.6212)" font-family="'TheSerif-HP5Plain'" font-size="25.8187">x</text>
 	<polyline fill="#FFFFFF" stroke="#000000" stroke-width="1.3" points="37.9,248.4 44.2,242.1 50.6,248.4 	"/>
 	<polyline fill="#FFFFFF" stroke="#000000" stroke-width="1.3" points="195.4,395.3 201.7,401.6 195.4,407.9 	"/>
 	<line fill="none" stroke="#000000" stroke-width="1.3" x1="201.7" y1="401.6" x2="-116.2" y2="401.6"/>


### PR DESCRIPTION
The SVG image showing 'Eighth Grade' coordinates had the x at the top and the y on the right. This fixes it.

Offending image is here:

https://processing.org/tutorials/drawing/imgs/drawing-03.svg

From this tutorial:

https://processing.org/tutorials/drawing/