### PR TITLE
Changes to the reference docs for pixels[] and some related functions

### DIFF
--- a/content/api_en/PImage_loadPixels.xml
+++ b/content/api_en/PImage_loadPixels.xml
@@ -35,7 +35,7 @@ void draw() {
 <description><![CDATA[
 Loads the pixel data for the image into its <b>pixels[]</b> array. This function must always be called before reading from or writing to <b>pixels[]</b>.
 <br /><br />
-Certain renderers may or may not seem to require <b>loadPixels()</b> or <b>updatePixels()</b>. However, the rule is that any time you want to manipulate the <b>pixels[]</b> array, you must first call <b>loadPixels()</b>, and after changes have been made, call <b>updatePixels()</b>. Even if the renderer may not seem to use this function in the current Processing release, this will always be subject to change.
+Certain renderers may or may not seem to require <b>loadPixels()</b> or <b>updatePixels()</b>. However, the rule is that any time you want to manipulate the <b>pixels[]</b> array, you must have previously called <b>loadPixels()</b>, and after changes have been made, call <b>updatePixels()</b>. Even if the renderer may not seem to use this function in the current Processing release, this will always be subject to change.
 ]]></description>
 
 </root>

--- a/content/api_en/PImage_pixels.xml
+++ b/content/api_en/PImage_pixels.xml
@@ -31,7 +31,9 @@ void draw() {
 </example>
 
 <description><![CDATA[
-Array containing the values for all the pixels in the image. These values are of the color datatype. This array is the size of the image, meaning if the image is 100 x 100 pixels, there will be 10000 values and if the window is 200 x 300 pixels, there will be 60000 values. The <b>index</b> value defines the position of a value within the array. For example, the statement <b>color b = img.pixels[230]</b> will set the variable <b>b</b> equal to the value at that location in the array. Before accessing this array, the data must loaded with the <b>loadPixels()</b> method. After the array data has been modified, the <b>updatePixels()</b> method must be run to update the changes. Without <b>loadPixels()</b>, running the code may (or will in future releases) result in a NullPointerException.
+Array containing the values for all the pixels in the image. These values are of the color datatype. This array is the size of the image, meaning if the image is 100 x 100 pixels, there will be 10000 values and if the window is 200 x 300 pixels, there will be 60000 values. <br />
+<br />
+Before accessing this array, the data must loaded with the <b>loadPixels()</b> method. Failure to do so may result in a NullPointerException. After the array data has been modified, the <b>updatePixels()</b> method must be run to update the content of the display window.
 ]]></description>
 
 </root>

--- a/content/api_en/loadPixels.xml
+++ b/content/api_en/loadPixels.xml
@@ -24,9 +24,9 @@ updatePixels();
 </example>
 
 <description><![CDATA[
-Loads the pixel data for the display window into the <b>pixels[]</b> array. This function must always be called before reading from or writing to <b>pixels[]</b>.<br />
+Loads a snapshot of the current display window into the <b>pixels[]</b> array. This function must always be called before reading from or writing to <b>pixels[]</b>. Subsequent changes to the display window will not be reflected in <b>pixels</b> until <b>loadPixels()</b> is called again.<br />
 <br />
-Certain renderers may or may not seem to require <b>loadPixels()</b> or <b>updatePixels()</b>. However, the rule is that any time you want to manipulate the <b>pixels[]</b> array, you must first call <b>loadPixels()</b>, and after changes have been made, call <b>updatePixels()</b>. Even if the renderer may not seem to use this function in the current Processing release, this will always be subject to change.
+Certain renderers may or may not seem to require <b>loadPixels()</b> or <b>updatePixels()</b>. However, the rule is that any time you want to manipulate the <b>pixels[]</b> array, you must have previously called <b>loadPixels()</b>, and after changes have been made, call <b>updatePixels()</b>. Even if the renderer may not seem to use this function in the current Processing release, this will always be subject to change.
 ]]></description>
 
 </root>

--- a/content/api_en/pixels.xml
+++ b/content/api_en/pixels.xml
@@ -21,9 +21,9 @@ updatePixels();
 </example>
 
 <description><![CDATA[
-Array containing the values for all the pixels in the display window. These values are of the color datatype. This array is the size of the display window. For example, if the image is 100x100 pixels, there will be 10000 values and if the window is 200x300 pixels, there will be 60000 values. The <b>index</b> value defines the position of a value within the array. For example, the statement <b>color b = pixels[230]</b> will set the variable <b>b</b> to be equal to the value at that location in the array.<br />
+Array containing the values for all the pixels in the display window. These values are of the color datatype. This array is the size of the display window. For example, if the image is 100x100 pixels, there will be 10000 values and if the window is 200x300 pixels, there will be 60000 values.<br />
 <br />
-Before accessing this array, the data must loaded with the <b>loadPixels()</b> function. After the array data has been modified, the <b>updatePixels()</b> function must be run to update the changes. Without <b>loadPixels()</b>, running the code may (or will in future releases) result in a NullPointerException.
+Before accessing this array, the data must loaded with the <b>loadPixels()</b> function. Failure to do so may result in a NullPointerException. Subsequent changes to the display window will not be reflected in <b>pixels</b> until <b>loadPixels()</b> is called again. After <b>pixels</b> has been modified, the <b>updatePixels()</b> function must be run to update the content of the display window.
 ]]></description>
 
 </root>


### PR DESCRIPTION
I don't think the docs were clear enough on the fact that `loadPixels()` stores a *snapshot* of the display in `pixels[]` (rather than opening a handle). [It tripped me up anyways.](https://forum.processing.org/two/discussion/15939/why-does-background-not-clear-the-display-here#latest)

I tried to make that clearer, and made some other wording changes while I was there.