### PR TITLE
Replace links to CC banner with secure version

### DIFF
--- a/java_generate/templates/class.template.html
+++ b/java_generate/templates/class.template.html
@@ -81,7 +81,7 @@ Updated on <!-- timestamp --><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-	<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
+	<a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/java_generate/templates/class.template.html
+++ b/java_generate/templates/class.template.html
@@ -81,7 +81,7 @@ Updated on <!-- timestamp --><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-	<a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
+	<a rel="license" href="//creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/java_generate/templates/generic.template.html
+++ b/java_generate/templates/generic.template.html
@@ -82,7 +82,7 @@ Updated on <!-- timestamp --><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-	<a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
+	<a rel="license" href="//creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/java_generate/templates/generic.template.html
+++ b/java_generate/templates/generic.template.html
@@ -82,7 +82,7 @@ Updated on <!-- timestamp --><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-	<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
+	<a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border: none" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/templates/foundation-template.reference.item.html
+++ b/templates/foundation-template.reference.item.html
@@ -7,7 +7,7 @@ Updated on <!--*-->updated<!--*--><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-   <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
+   <a rel="license" href="//creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/templates/foundation-template.reference.item.html
+++ b/templates/foundation-template.reference.item.html
@@ -7,7 +7,7 @@ Updated on <!--*-->updated<!--*--><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-   <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
+   <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/templates/template.reference.item.html
+++ b/templates/template.reference.item.html
@@ -7,7 +7,7 @@ Updated on <!--*-->updated<!--*--><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-   <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
+   <a rel="license" href="//creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 

--- a/templates/template.reference.item.html
+++ b/templates/template.reference.item.html
@@ -7,7 +7,7 @@ Updated on <!--*-->updated<!--*--><br /><br />
 <!-- Creative Commons License -->
 
 <div class="license">
-   <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
+   <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>
 </div>
 <!--
 


### PR DESCRIPTION
Should make browsers so happy that they would on most reference pages display green lock instead of "parts of this webpage are not secure".

Current insecure links redirect on their own to the secure links I used, so nothing should change.