### PR TITLE
Ortho example in p3d tutorial is broken

### DIFF
--- a/content/static/tutorials/p3d/index.html
+++ b/content/static/tutorials/p3d/index.html
@@ -394,7 +394,7 @@ void draw()  {
     float cameraZ = (height/2.0) / tan(fov/2.0); 
     perspective(fov, float(width)/float(height), cameraZ/2.0, cameraZ*2.0); 
   } else {
-    ortho(0, width, 0, height); 
+    ortho(-width/2, width/2, -height/2, height/2);
   }
   translate(width/2, height/2, 0);
   rotateX(-PI/6); 


### PR DESCRIPTION
Fix example code in p3d tutorial that does not work as expected after changes in `ortho()` (processing/processing#1278).