### PR TITLE
Rename "OS X" to "Mac"

### DIFF
--- a/content/api_en/LIB_pdf/index.html
+++ b/content/api_en/LIB_pdf/index.html
@@ -281,7 +281,7 @@ bitmapped and ugly. In some cases, hint(ENABLE_NATIVE_FONTS)
 may improve the situation if the font is installed on the machine.
 
 <!-- Removed by REAS, 1 September 2011, couldn't find reference in the current Issue database-->
-<!--<li>On Mac OS X, the seems to be a bug in Apple's Java implementation 
+<!--<li>On macOS, the seems to be a bug in Apple's Java implementation 
 that confuses cubic vs. quadric splines. This makes text look jagged, 
 even though it's not bitmapped.
 (<A HREF="http://dev.processing.org/bugs/show_bug.cgi?id=404">Bug 404</A>)-->

--- a/content/api_en/LIB_pdf/index.html
+++ b/content/api_en/LIB_pdf/index.html
@@ -281,7 +281,7 @@ bitmapped and ugly. In some cases, hint(ENABLE_NATIVE_FONTS)
 may improve the situation if the font is installed on the machine.
 
 <!-- Removed by REAS, 1 September 2011, couldn't find reference in the current Issue database-->
-<!--<li>On macOS, the seems to be a bug in Apple's Java implementation 
+<!--<li>On Mac, the seems to be a bug in Apple's Java implementation 
 that confuses cubic vs. quadric splines. This makes text look jagged, 
 even though it's not bitmapped.
 (<A HREF="http://dev.processing.org/bugs/show_bug.cgi?id=404">Bug 404</A>)-->

--- a/content/api_en/displayDensity.xml
+++ b/content/api_en/displayDensity.xml
@@ -26,7 +26,7 @@ void draw() {
 </example>
 
 <description><![CDATA[
-This function returns the number "2" if the screen is a high-density screen (called a Retina display on OS X or high-dpi on Windows and Linux) and a "1" if not. This information is useful for a program to adapt to run at double the pixel density on a screen that supports it.
+This function returns the number "2" if the screen is a high-density screen (called a Retina display on macOS or high-dpi on Windows and Linux) and a "1" if not. This information is useful for a program to adapt to run at double the pixel density on a screen that supports it.
 ]]></description>
 
 </root>

--- a/content/api_en/displayDensity.xml
+++ b/content/api_en/displayDensity.xml
@@ -26,7 +26,7 @@ void draw() {
 </example>
 
 <description><![CDATA[
-This function returns the number "2" if the screen is a high-density screen (called a Retina display on macOS or high-dpi on Windows and Linux) and a "1" if not. This information is useful for a program to adapt to run at double the pixel density on a screen that supports it.
+This function returns the number "2" if the screen is a high-density screen (called a Retina display on Mac or high-dpi on Windows and Linux) and a "1" if not. This information is useful for a program to adapt to run at double the pixel density on a screen that supports it.
 ]]></description>
 
 </root>

--- a/content/api_en/environment/index.html
+++ b/content/api_en/environment/index.html
@@ -135,10 +135,10 @@ Big-picture keywords / concepts for getting into Processing
       Prints the code inside the text editor.</li>
     <li><em>Preferences</em><br />
       Change some of the ways Processing works. (This item is located in the Processing menu 
-      on Mac OS X.)</li>
+      on macOS.)</li>
     <li><em>Quit</em><br />
       Exits the Processing Environment and closes all Processing windows. (This item is
-      located in the Processing menu on Mac OS X.)</li>
+      located in the Processing menu on macOS.)</li>
 	</ul>
 	
 	<h6>Edit</h6>
@@ -278,7 +278,7 @@ ff    <li><em>Step Into</em><br />
     <p>
 		The Processing Development Environment (PDE) is highly configurable. The most common
 		preferences can be modified in the Preferences window, located in the File menu on
-		Windows and Linux and in the Processing menu on Mac Os X. The full list of preferences 
+		Windows and Linux and in the Processing menu on macOS. The full list of preferences 
 		are stored in the "preferences.txt" file. This file can be opened and edited directly 
 		only when Processing is not running. You can find the location of this file on your 
 		computer by reading the bottom-left corner of the Preferences window.
@@ -503,7 +503,7 @@ ff    <li><em>Step Into</em><br />
     
     <p>
     	This mode makes it possible to write short programs to draw to the screen, but also enables complex Java programs as well. It can be used simply by beginners, but it scales to professional Java software development. Sketches written in this mode can
-    	be exported as Java Applications to run on Linux, Mac OS X, and Windows operating systems. 
+    	be exported as Java Applications to run on Linux, macOS, and Windows operating systems. 
     </p>
     
     <p>

--- a/content/api_en/environment/index.html
+++ b/content/api_en/environment/index.html
@@ -135,10 +135,10 @@ Big-picture keywords / concepts for getting into Processing
       Prints the code inside the text editor.</li>
     <li><em>Preferences</em><br />
       Change some of the ways Processing works. (This item is located in the Processing menu 
-      on macOS.)</li>
+      on Mac.)</li>
     <li><em>Quit</em><br />
       Exits the Processing Environment and closes all Processing windows. (This item is
-      located in the Processing menu on macOS.)</li>
+      located in the Processing menu on Mac.)</li>
 	</ul>
 	
 	<h6>Edit</h6>
@@ -278,7 +278,7 @@ ff    <li><em>Step Into</em><br />
     <p>
 		The Processing Development Environment (PDE) is highly configurable. The most common
 		preferences can be modified in the Preferences window, located in the File menu on
-		Windows and Linux and in the Processing menu on macOS. The full list of preferences 
+		Windows and Linux and in the Processing menu on Mac. The full list of preferences 
 		are stored in the "preferences.txt" file. This file can be opened and edited directly 
 		only when Processing is not running. You can find the location of this file on your 
 		computer by reading the bottom-left corner of the Preferences window.
@@ -503,7 +503,7 @@ ff    <li><em>Step Into</em><br />
     
     <p>
     	This mode makes it possible to write short programs to draw to the screen, but also enables complex Java programs as well. It can be used simply by beginners, but it scales to professional Java software development. Sketches written in this mode can
-    	be exported as Java Applications to run on Linux, macOS, and Windows operating systems. 
+    	be exported as Java Applications to run on Linux, Mac, and Windows operating systems. 
     </p>
     
     <p>

--- a/content/api_en/launch.xml
+++ b/content/api_en/launch.xml
@@ -32,7 +32,7 @@ Attempts to open an application or file using your platform's launcher. The <b>f
 <br />
 This function (roughly) emulates what happens when you double-click an application or document in the macOS Finder, the Windows Explorer, or your favorite Linux file manager. If you're trying to run command line functions directly, use the <b>exec()</b> function instead (see below).<br />
 <br />
-This function behaves differently on each platform. On Windows, the parameters are sent to the Windows shell via "cmd /c". On Mac OS X, the "open" command is used (type "man open" in Terminal.app for documentation). On Linux, it first tries gnome-open, then kde-open, but if neither are available, it sends the command to the shell and prays that something useful happens.<br />
+This function behaves differently on each platform. On Windows, the parameters are sent to the Windows shell via "cmd /c". On macOS, the "open" command is used (type "man open" in Terminal.app for documentation). On Linux, it first tries gnome-open, then kde-open, but if neither are available, it sends the command to the shell and prays that something useful happens.<br />
 <br />
 For users familiar with Java, this is not the same as Runtime.exec(), because the launcher command is prepended. Instead, the <b>exec(String[])</b> function is a shortcut for Runtime.getRuntime.exec(String[]). The <b>exec()</b> function is documented in the <a href="http://processing.github.io/processing-javadocs/core/">JavaDoc</a> in the <b>PApplet</b> class.
 ]]></description>

--- a/content/api_en/launch.xml
+++ b/content/api_en/launch.xml
@@ -30,9 +30,9 @@ void mousePressed() {
 <description><![CDATA[
 Attempts to open an application or file using your platform's launcher. The <b>filename</b> parameter is a String specifying the file name and location. The location parameter must be a full path name, or the name of an executable in the system's PATH. In most cases, using a full path is the best option, rather than relying on the system PATH. Be sure to make the file executable before attempting to open it (chmod +x).<br />
 <br />
-This function (roughly) emulates what happens when you double-click an application or document in the macOS Finder, the Windows Explorer, or your favorite Linux file manager. If you're trying to run command line functions directly, use the <b>exec()</b> function instead (see below).<br />
+This function (roughly) emulates what happens when you double-click an application or document in the Mac Finder, the Windows Explorer, or your favorite Linux file manager. If you're trying to run command line functions directly, use the <b>exec()</b> function instead (see below).<br />
 <br />
-This function behaves differently on each platform. On Windows, the parameters are sent to the Windows shell via "cmd /c". On macOS, the "open" command is used (type "man open" in Terminal.app for documentation). On Linux, it first tries gnome-open, then kde-open, but if neither are available, it sends the command to the shell and prays that something useful happens.<br />
+This function behaves differently on each platform. On Windows, the parameters are sent to the Windows shell via "cmd /c". On Mac, the "open" command is used (type "man open" in Terminal.app for documentation). On Linux, it first tries gnome-open, then kde-open, but if neither are available, it sends the command to the shell and prays that something useful happens.<br />
 <br />
 For users familiar with Java, this is not the same as Runtime.exec(), because the launcher command is prepended. Instead, the <b>exec(String[])</b> function is a shortcut for Runtime.getRuntime.exec(String[]). The <b>exec()</b> function is documented in the <a href="http://processing.github.io/processing-javadocs/core/">JavaDoc</a> in the <b>PApplet</b> class.
 ]]></description>

--- a/content/api_en/mouseWheel.xml
+++ b/content/api_en/mouseWheel.xml
@@ -26,7 +26,7 @@ void mouseWheel(MouseEvent event) {
 </example>
 
 <description><![CDATA[
-The <b>mouseWheel()</b> function returns positive values when the mouse wheel is rotated down (toward the user), and negative values for the other direction (up or away from the user). On macOS with "natural" scrolling enabled, the values are opposite.
+The <b>mouseWheel()</b> function returns positive values when the mouse wheel is rotated down (toward the user), and negative values for the other direction (up or away from the user). On Mac with "natural" scrolling enabled, the values are opposite.
 <br /><br />
 Mouse and keyboard events only work when a program has <b>draw()</b>. Without <b>draw()</b>, the code is only run once and then stops listening for events.
 ]]></description>

--- a/content/api_en/mouseWheel.xml
+++ b/content/api_en/mouseWheel.xml
@@ -26,7 +26,7 @@ void mouseWheel(MouseEvent event) {
 </example>
 
 <description><![CDATA[
-The <b>mouseWheel()</b> function returns positive values when the mouse wheel is rotated down (toward the user), and negative values for the other direction (up or away from the user). On OS X with "natural" scrolling enabled, the values are opposite.
+The <b>mouseWheel()</b> function returns positive values when the mouse wheel is rotated down (toward the user), and negative values for the other direction (up or away from the user). On macOS with "natural" scrolling enabled, the values are opposite.
 <br /><br />
 Mouse and keyboard events only work when a program has <b>draw()</b>. Without <b>draw()</b>, the code is only run once and then stops listening for events.
 ]]></description>

--- a/content/api_en/pixelHeight.xml
+++ b/content/api_en/pixelHeight.xml
@@ -16,7 +16,7 @@ println(pixelWidth, pixelHeight);
 </example>
 
 <description><![CDATA[
-When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on macOS or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
+When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on Mac or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/pixelHeight.xml
+++ b/content/api_en/pixelHeight.xml
@@ -16,7 +16,7 @@ println(pixelWidth, pixelHeight);
 </example>
 
 <description><![CDATA[
-When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on OS X or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
+When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on macOS or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/pixelWidth.xml
+++ b/content/api_en/pixelWidth.xml
@@ -16,7 +16,7 @@ println(pixelWidth, pixelHeight);
 </example>
 
 <description><![CDATA[
-When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on macOS or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
+When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on Mac or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/pixelWidth.xml
+++ b/content/api_en/pixelWidth.xml
@@ -16,7 +16,7 @@ println(pixelWidth, pixelHeight);
 </example>
 
 <description><![CDATA[
-When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on OS X or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
+When <b>pixelDensity(2)</b> is used to make use of a high resolution display (called a Retina display on macOS or high-dpi on Windows and Linux), the width and height of the sketch do not change, but the number of pixels is doubled. As a result, all operations that use pixels (like <b>loadPixels()</b>, <b>get()</b>, <b>set()</b>, etc.) happen in this doubled space. As a convenience, the variables <b>pixelWidth</b> and <b>pixelHeight</b> hold the actual width and height of the sketch in pixels. This is useful for any sketch that uses the <b>pixels[]</b> array, for instance, because the number of elements in the array will be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/size.xml
+++ b/content/api_en/size.xml
@@ -61,7 +61,7 @@ As of Processing 3, to run a sketch at the full dimensions of a screen, use the 
 <br />
 The maximum width and height is limited by your operating system, and is usually the width and height of your actual screen. On some machines it may simply be the number of pixels on your current screen, meaning that a screen of 800 x 600 could support <b>size(1600, 300)</b>, since that is the same number of pixels. This varies widely, so you'll have to try different rendering modes and sizes until you get what you're looking for. If you need something larger, use <b>createGraphics</b> to create a non-visible drawing surface.<br />
 <br />
-The minimum width and height is around 100 pixels in each direction. This is the smallest that is supported across Windows, macOS, and Linux. We enforce the minimum size so that sketches will run identically on different machines.
+The minimum width and height is around 100 pixels in each direction. This is the smallest that is supported across Windows, Mac, and Linux. We enforce the minimum size so that sketches will run identically on different machines.
 <br />
 The <b>renderer</b> parameter selects which rendering engine to use. For example, if you will be drawing 3D shapes, use <b>P3D</b>. In addition to the default renderer, other renderers are:<br />
 <br />

--- a/content/static/tutorials/data/index.html
+++ b/content/static/tutorials/data/index.html
@@ -183,7 +183,7 @@ void setup() {
 	</p>
 
 	<p>
-		In order to create a text file, you can use any simple text editor. Windows Notepad or Mac OS X TextEdit will do; just make sure you format the file as “plain text.” It is also advisable to name the text files with the “.txt” extension, to avoid any confusion. And just as with image files, these text files should be placed in the sketch’s “data” directory in order for them to be recognized by the Processing sketch.</p>
+		In order to create a text file, you can use any simple text editor. Windows Notepad or macOS TextEdit will do; just make sure you format the file as “plain text.” It is also advisable to name the text files with the “.txt” extension, to avoid any confusion. And just as with image files, these text files should be placed in the sketch’s “data” directory in order for them to be recognized by the Processing sketch.</p>
 		
 	<p>
 		Once the text file is in place, Processing’s <tt>loadStrings()</tt> function is used to read the content of the file into a <tt>String</tt> array. The individual lines of text in the file each become an individual element in the array.

--- a/content/static/tutorials/data/index.html
+++ b/content/static/tutorials/data/index.html
@@ -183,7 +183,7 @@ void setup() {
 	</p>
 
 	<p>
-		In order to create a text file, you can use any simple text editor. Windows Notepad or macOS TextEdit will do; just make sure you format the file as “plain text.” It is also advisable to name the text files with the “.txt” extension, to avoid any confusion. And just as with image files, these text files should be placed in the sketch’s “data” directory in order for them to be recognized by the Processing sketch.</p>
+		In order to create a text file, you can use any simple text editor. Windows Notepad or Mac TextEdit will do; just make sure you format the file as “plain text.” It is also advisable to name the text files with the “.txt” extension, to avoid any confusion. And just as with image files, these text files should be placed in the sketch’s “data” directory in order for them to be recognized by the Processing sketch.</p>
 		
 	<p>
 		Once the text file is in place, Processing’s <tt>loadStrings()</tt> function is used to read the content of the file into a <tt>String</tt> array. The individual lines of text in the file each become an individual element in the array.

--- a/content/static/tutorials/eclipse/index.html
+++ b/content/static/tutorials/eclipse/index.html
@@ -35,7 +35,7 @@
 <h3>Import the Processing Core</h3>
 <p>In order for Eclipse to see the code that makes up Processing, we need to import it into our project.</p>
 <p><em>File &gt; Import &gt; General &gt; File System</em></p>
-<p>Click next. On Windows, click "Browse..." and select the Processing jar files inside PATH_TO_PROCESSING/core/library/. On macOS, do not use the "Browse..." button. Instead, use the "From directory:" field to manually enter the path to Processing's jar files, which is typically /Applications/Processing 3.app/Contents/Java/core/library/. At minimum, select the "core.jar" file inside the "library" folder.</p>
+<p>Click next. On Windows, click "Browse..." and select the Processing jar files inside PATH_TO_PROCESSING/core/library/. On Mac, do not use the "Browse..." button. Instead, use the "From directory:" field to manually enter the path to Processing's jar files, which is typically /Applications/Processing 3.app/Contents/Java/core/library/. At minimum, select the "core.jar" file inside the "library" folder.</p>
 <p><img src="imgs/importcore.png" border="1" alt="Importing the Processing Core" /></p>
 <p>A .jar file is a compiled collection of Java code. The core.jar is the core of the Processing libraries, it has all the code that does the stuff that we are used to doing in Processing, like drawing shapes. Once we have it, we can make use of all the normal Processing commands that are found on the&nbsp;<a href="https://processing.org/reference/">reference page</a>.</p>
 <p>Click Finish. If you look at the Package Explorer, you'll notice that there is a new file in our project, called 'core.jar'.</p>

--- a/content/static/tutorials/eclipse/index.html
+++ b/content/static/tutorials/eclipse/index.html
@@ -35,7 +35,7 @@
 <h3>Import the Processing Core</h3>
 <p>In order for Eclipse to see the code that makes up Processing, we need to import it into our project.</p>
 <p><em>File &gt; Import &gt; General &gt; File System</em></p>
-<p>Click next. On Windows, click "Browse..." and select the Processing jar files inside PATH_TO_PROCESSING/core/library/. On OS X, do not use the "Browse..." button. Instead, use the "From directory:" field to manually enter the path to Processing's jar files, which is typically /Applications/Processing 3.app/Contents/Java/core/library/. At minimum, select the "core.jar" file inside the "library" folder.</p>
+<p>Click next. On Windows, click "Browse..." and select the Processing jar files inside PATH_TO_PROCESSING/core/library/. On macOS, do not use the "Browse..." button. Instead, use the "From directory:" field to manually enter the path to Processing's jar files, which is typically /Applications/Processing 3.app/Contents/Java/core/library/. At minimum, select the "core.jar" file inside the "library" folder.</p>
 <p><img src="imgs/importcore.png" border="1" alt="Importing the Processing Core" /></p>
 <p>A .jar file is a compiled collection of Java code. The core.jar is the core of the Processing libraries, it has all the code that does the stuff that we are used to doing in Processing, like drawing shapes. Once we have it, we can make use of all the normal Processing commands that are found on the&nbsp;<a href="https://processing.org/reference/">reference page</a>.</p>
 <p>Click Finish. If you look at the Package Explorer, you'll notice that there is a new file in our project, called 'core.jar'.</p>

--- a/content/static/tutorials/electronics/index.html
+++ b/content/static/tutorials/electronics/index.html
@@ -273,7 +273,7 @@
 	</p>
 
 	<p class="txt">
-		Because a device can have several serial ports, a user must specify which serial port to use for data transmission. On most Windows computers, serial port names are <code>COMx</code>, where <code>x</code> can be 1, 2, 3, etc. On UNIX-based systems (macOS and Linux), serial devices are accessed through files in the <em>/dev/</em> directory. After the serial port is selected, the user must specify the settings for the port. Communication speed will vary with devices, but typical values are 9600, 19,200, and 115,200 bits per second. Once the ports are open for communication on both devices, it is possible to send and receive data.
+		Because a device can have several serial ports, a user must specify which serial port to use for data transmission. On most Windows computers, serial port names are <code>COMx</code>, where <code>x</code> can be 1, 2, 3, etc. On UNIX-based systems (Mac and Linux), serial devices are accessed through files in the <em>/dev/</em> directory. After the serial port is selected, the user must specify the settings for the port. Communication speed will vary with devices, but typical values are 9600, 19,200, and 115,200 bits per second. Once the ports are open for communication on both devices, it is possible to send and receive data.
 	</p>
 
 	<p class="txt">

--- a/content/static/tutorials/electronics/index.html
+++ b/content/static/tutorials/electronics/index.html
@@ -273,7 +273,7 @@
 	</p>
 
 	<p class="txt">
-		Because a device can have several serial ports, a user must specify which serial port to use for data transmission. On most Windows computers, serial port names are <code>COMx</code>, where <code>x</code> can be 1, 2, 3, etc. On UNIX-based systems (Mac OS X and Linux), serial devices are accessed through files in the <em>/dev/</em> directory. After the serial port is selected, the user must specify the settings for the port. Communication speed will vary with devices, but typical values are 9600, 19,200, and 115,200 bits per second. Once the ports are open for communication on both devices, it is possible to send and receive data.
+		Because a device can have several serial ports, a user must specify which serial port to use for data transmission. On most Windows computers, serial port names are <code>COMx</code>, where <code>x</code> can be 1, 2, 3, etc. On UNIX-based systems (macOS and Linux), serial devices are accessed through files in the <em>/dev/</em> directory. After the serial port is selected, the user must specify the settings for the port. Communication speed will vary with devices, but typical values are 9600, 19,200, and 115,200 bits per second. Once the ports are open for communication on both devices, it is possible to send and receive data.
 	</p>
 
 	<p class="txt">

--- a/content/static/tutorials/gettingstarted/index.html
+++ b/content/static/tutorials/gettingstarted/index.html
@@ -17,7 +17,7 @@
 			the desktop, but the important thing is for the processing folder to be
 			pulled out of that .zip file. Then double-click processing.exe to start.</li>
 
-		<li>The Mac OS X version is also a .zip file. Double-click it and drag the Processing
+		<li>The macOS version is also a .zip file. Double-click it and drag the Processing
 			icon to the Applications folder. If you're using someone else's machine
 			and can't modify the Applications folder, just drag the application to the
 			desktop. Then double-click the Processing icon to start.</li>

--- a/content/static/tutorials/gettingstarted/index.html
+++ b/content/static/tutorials/gettingstarted/index.html
@@ -17,7 +17,7 @@
 			the desktop, but the important thing is for the processing folder to be
 			pulled out of that .zip file. Then double-click processing.exe to start.</li>
 
-		<li>The macOS version is also a .zip file. Double-click it and drag the Processing
+		<li>The Mac version is also a .zip file. Double-click it and drag the Processing
 			icon to the Applications folder. If you're using someone else's machine
 			and can't modify the Applications folder, just drag the application to the
 			desktop. Then double-click the Processing icon to start.</li>

--- a/content/static/tutorials/overview/index.html
+++ b/content/static/tutorials/overview/index.html
@@ -155,7 +155,7 @@
 		
 		
 		<p class="txt">
-      One of the most significant features of the Processing environment is its ability to bundle your sketch into an application with just one click. Select File &rarr; Export Application to package your current sketch as an application. This will bundle your sketch as an application for Windows, Mac OS X, or Linux depending on which operating system you're exporting from. The application folders are overwritten whenever you export&mdash;make a copy or remove them from the sketch folder before making changes to the contents of the folder. Alternatively, you can turn off the automatic file erasure in the Preferences.
+      One of the most significant features of the Processing environment is its ability to bundle your sketch into an application with just one click. Select File &rarr; Export Application to package your current sketch as an application. This will bundle your sketch as an application for Windows, macOS, or Linux depending on which operating system you're exporting from. The application folders are overwritten whenever you export&mdash;make a copy or remove them from the sketch folder before making changes to the contents of the folder. Alternatively, you can turn off the automatic file erasure in the Preferences.
     </p>
 
     <p class="txt">

--- a/content/static/tutorials/overview/index.html
+++ b/content/static/tutorials/overview/index.html
@@ -155,7 +155,7 @@
 		
 		
 		<p class="txt">
-      One of the most significant features of the Processing environment is its ability to bundle your sketch into an application with just one click. Select File &rarr; Export Application to package your current sketch as an application. This will bundle your sketch as an application for Windows, macOS, or Linux depending on which operating system you're exporting from. The application folders are overwritten whenever you export&mdash;make a copy or remove them from the sketch folder before making changes to the contents of the folder. Alternatively, you can turn off the automatic file erasure in the Preferences.
+      One of the most significant features of the Processing environment is its ability to bundle your sketch into an application with just one click. Select File &rarr; Export Application to package your current sketch as an application. This will bundle your sketch as an application for Windows, Mac, or Linux depending on which operating system you're exporting from. The application folders are overwritten whenever you export&mdash;make a copy or remove them from the sketch folder before making changes to the contents of the folder. Alternatively, you can turn off the automatic file erasure in the Preferences.
     </p>
 
     <p class="txt">

--- a/download/_downloads.php
+++ b/download/_downloads.php
@@ -1,7 +1,7 @@
 <!-- BEGIN [Download] -->
 <div class="download">
 
-	<h1 class="large-header"><span class="black">Download Processing.</span> Processing is available for Linux, macOS, and Windows. Select your choice to download the software below.</h1>
+	<h1 class="large-header"><span class="black">Download Processing.</span> Processing is available for Linux, Mac, and Windows. Select your choice to download the software below.</h1>
 	<? if($thankYou): ?>
 	<h5>Thank you for donating to the Processing Foundation.</h5>
 	<? endif; ?>
@@ -21,7 +21,7 @@
 				<li><a href="http://download.processing.org/processing-3.2.3-linux64.tgz">Linux</a> 64-bit<br />
 				<a href="http://download.processing.org/processing-3.2.3-linux32.tgz">Linux</a> 32-bit<br />
 				<a href="http://download.processing.org/processing-3.2.3-linux-armv6hf.tgz">Linux</a> ARMv6hf</li>
-				<li><a href="http://download.processing.org/processing-3.2.3-macosx.zip">macOS</a></li>
+				<li><a href="http://download.processing.org/processing-3.2.3-macosx.zip">Mac</a></li>
 
 			</ul>
 		</div>
@@ -52,7 +52,7 @@
 				<a href="http://download.processing.org/processing-3.2.3-linux32.tgz">Linux 32</a> 
 				<a href="http://download.processing.org/processing-3.2.3-linux64.tgz">Linux 64</a>
 				<a href="http://download.processing.org/processing-3.2.3-linux-armv6hf.tgz">Linux ARMv6hf</a>
-				<a href="http://download.processing.org/processing-3.2.3-macosx.zip">macOS</a> 
+				<a href="http://download.processing.org/processing-3.2.3-macosx.zip">Mac</a> 
 			</li>
                         <li>
 				<span class="version">3.2.2</span>
@@ -62,7 +62,7 @@
 				<a href="http://download.processing.org/processing-3.2.2-linux32.tgz">Linux 32</a> 
 				<a href="http://download.processing.org/processing-3.2.2-linux64.tgz">Linux 64</a>
 				<a href="http://download.processing.org/processing-3.2.2-linux-armv6hf.tgz">Linux ARMv6hf</a>
-				<a href="http://download.processing.org/processing-3.2.2-macosx.zip"macOS</a> 
+				<a href="http://download.processing.org/processing-3.2.2-macosx.zip"Mac</a> 
 			</li>
 
 <!--                        
@@ -96,7 +96,7 @@
 				<a href="http://download.processing.org/processing-2.2.1-windows64.zip">Win 64</a> 
 				<a href="http://download.processing.org/processing-2.2.1-linux32.tgz">Linux 32</a> 
 				<a href="http://download.processing.org/processing-2.2.1-linux64.tgz">Linux 64</a>
-				<a href="http://download.processing.org/processing-2.2.1-macosx.zip">macOS</a> 
+				<a href="http://download.processing.org/processing-2.2.1-macosx.zip">Mac</a> 
 			</li>
 
 			<li>
@@ -105,7 +105,7 @@
 				<a href="http://download.processing.org/processing-1.5.1-windows.zip">Win (standard)</a>
 				<a href="http://download.processing.org/processing-1.5.1-windows-expert.zip">Win (no Java)</a> 
 				<a href="http://download.processing.org/processing-1.5.1-linux.tgz">Linux x86</a> 
-				<a href="http://download.processing.org/processing-1.5.1-macosx.zip">macOS</a> 
+				<a href="http://download.processing.org/processing-1.5.1-macosx.zip">Mac</a> 
 			</li>
 		</ul>
 		<p>Earlier releases have been removed because we can only support the current versions of the software. To update old code, read the <a href="https://github.com/processing/processing/wiki/Changes">changes</a> page. Changes for each release can be found in <a href="https://raw.github.com/processing/processing/master/build/shared/revisions.txt">revisions.txt</a>. If you have problems with the current release, please <a href="https://github.com/processing/processing/issues?state=open">file a bug</a> so that we can fix it. Older releases can also be <a href="https://github.com/processing/processing">built from the source</a>. <a href="https://github.com/processing/processing/wiki/FAQ#whats-with-the-version-numbers">Read More</a> about the releases and their numbering. To use <a href="http://android.processing.org">Android Mode</a>, Processing 3 or later is required.</p>

--- a/download/_downloads.php
+++ b/download/_downloads.php
@@ -1,7 +1,7 @@
 <!-- BEGIN [Download] -->
 <div class="download">
 
-	<h1 class="large-header"><span class="black">Download Processing.</span> Processing is available for Linux, Mac OS X, and Windows. Select your choice to download the software below.</h1>
+	<h1 class="large-header"><span class="black">Download Processing.</span> Processing is available for Linux, macOS, and Windows. Select your choice to download the software below.</h1>
 	<? if($thankYou): ?>
 	<h5>Thank you for donating to the Processing Foundation.</h5>
 	<? endif; ?>
@@ -21,7 +21,7 @@
 				<li><a href="http://download.processing.org/processing-3.2.3-linux64.tgz">Linux</a> 64-bit<br />
 				<a href="http://download.processing.org/processing-3.2.3-linux32.tgz">Linux</a> 32-bit<br />
 				<a href="http://download.processing.org/processing-3.2.3-linux-armv6hf.tgz">Linux</a> ARMv6hf</li>
-				<li><a href="http://download.processing.org/processing-3.2.3-macosx.zip">Mac OS X</a></li>
+				<li><a href="http://download.processing.org/processing-3.2.3-macosx.zip">macOS</a></li>
 
 			</ul>
 		</div>
@@ -52,7 +52,7 @@
 				<a href="http://download.processing.org/processing-3.2.3-linux32.tgz">Linux 32</a> 
 				<a href="http://download.processing.org/processing-3.2.3-linux64.tgz">Linux 64</a>
 				<a href="http://download.processing.org/processing-3.2.3-linux-armv6hf.tgz">Linux ARMv6hf</a>
-				<a href="http://download.processing.org/processing-3.2.3-macosx.zip">Mac OS X</a> 
+				<a href="http://download.processing.org/processing-3.2.3-macosx.zip">macOS</a> 
 			</li>
                         <li>
 				<span class="version">3.2.2</span>
@@ -62,7 +62,7 @@
 				<a href="http://download.processing.org/processing-3.2.2-linux32.tgz">Linux 32</a> 
 				<a href="http://download.processing.org/processing-3.2.2-linux64.tgz">Linux 64</a>
 				<a href="http://download.processing.org/processing-3.2.2-linux-armv6hf.tgz">Linux ARMv6hf</a>
-				<a href="http://download.processing.org/processing-3.2.2-macosx.zip">Mac OS X</a> 
+				<a href="http://download.processing.org/processing-3.2.2-macosx.zip"macOS</a> 
 			</li>
 
 <!--                        
@@ -96,7 +96,7 @@
 				<a href="http://download.processing.org/processing-2.2.1-windows64.zip">Win 64</a> 
 				<a href="http://download.processing.org/processing-2.2.1-linux32.tgz">Linux 32</a> 
 				<a href="http://download.processing.org/processing-2.2.1-linux64.tgz">Linux 64</a>
-				<a href="http://download.processing.org/processing-2.2.1-macosx.zip">Mac OS X</a> 
+				<a href="http://download.processing.org/processing-2.2.1-macosx.zip">macOS</a> 
 			</li>
 
 			<li>
@@ -105,7 +105,7 @@
 				<a href="http://download.processing.org/processing-1.5.1-windows.zip">Win (standard)</a>
 				<a href="http://download.processing.org/processing-1.5.1-windows-expert.zip">Win (no Java)</a> 
 				<a href="http://download.processing.org/processing-1.5.1-linux.tgz">Linux x86</a> 
-				<a href="http://download.processing.org/processing-1.5.1-macosx.zip">Mac OS X</a> 
+				<a href="http://download.processing.org/processing-1.5.1-macosx.zip">macOS</a> 
 			</li>
 		</ul>
 		<p>Earlier releases have been removed because we can only support the current versions of the software. To update old code, read the <a href="https://github.com/processing/processing/wiki/Changes">changes</a> page. Changes for each release can be found in <a href="https://raw.github.com/processing/processing/master/build/shared/revisions.txt">revisions.txt</a>. If you have problems with the current release, please <a href="https://github.com/processing/processing/issues?state=open">file a bug</a> so that we can fix it. Older releases can also be <a href="https://github.com/processing/processing">built from the source</a>. <a href="https://github.com/processing/processing/wiki/FAQ#whats-with-the-version-numbers">Read More</a> about the releases and their numbering. To use <a href="http://android.processing.org">Android Mode</a>, Processing 3 or later is required.</p>

--- a/generate/lib/XPath.class.php
+++ b/generate/lib/XPath.class.php
@@ -213,7 +213,7 @@ class XPathBase {
       case 'Windows_95':
       case 'Windows_98':
       case 'Unknown OS':
-        // should catch macOS compatible environment 
+        // should catch Mac compatible environment 
         if (!empty($_SERVER['SERVER_SOFTWARE']) 
             && preg_match('/Darwin/',$_SERVER['SERVER_SOFTWARE'])) { 
            // fall-through 

--- a/generate/lib/XPath.class.php
+++ b/generate/lib/XPath.class.php
@@ -213,7 +213,7 @@ class XPathBase {
       case 'Windows_95':
       case 'Windows_98':
       case 'Unknown OS':
-        // should catch Mac OS X compatible environment 
+        // should catch macOS compatible environment 
         if (!empty($_SERVER['SERVER_SOFTWARE']) 
             && preg_match('/Darwin/',$_SERVER['SERVER_SOFTWARE'])) { 
            // fall-through 

--- a/templates/template.cover.html
+++ b/templates/template.cover.html
@@ -17,7 +17,7 @@
             	<li>&raquo; Free to download and open source</li>
             	<li>&raquo; Interactive programs with 2D, 3D or PDF output</li>
             	<li>&raquo; OpenGL integration for accelerated 2D and 3D</li>
-            	<li>&raquo; For GNU/Linux, macOS, and Windows</li>
+            	<li>&raquo; For GNU/Linux, Mac, and Windows</li>
             	<li>&raquo; Over 100 libraries extend the core software</li>
             	<li>&raquo; Well <a href="./reference/">documented</a>, with many <a href="./books/">books</a> available</li>
             </ul>

--- a/templates/template.cover.html
+++ b/templates/template.cover.html
@@ -17,7 +17,7 @@
             	<li>&raquo; Free to download and open source</li>
             	<li>&raquo; Interactive programs with 2D, 3D or PDF output</li>
             	<li>&raquo; OpenGL integration for accelerated 2D and 3D</li>
-            	<li>&raquo; For GNU/Linux, Mac OS X, and Windows</li>
+            	<li>&raquo; For GNU/Linux, macOS, and Windows</li>
             	<li>&raquo; Over 100 libraries extend the core software</li>
             	<li>&raquo; Well <a href="./reference/">documented</a>, with many <a href="./books/">books</a> available</li>
             </ul>


### PR DESCRIPTION
Like #516, but using the more generic "Mac" - as suggested by @REAS 