### PR TITLE
Document Topics/Shaders/DomeProjection caveat

### DIFF
--- a/content/examples/Topics/Shaders/DomeProjection/DomeProjection.pde
+++ b/content/examples/Topics/Shaders/DomeProjection/DomeProjection.pde
@@ -6,6 +6,8 @@
  * 
  * Based on the FullDomeTemplate code from Christopher Warnow: 
  * https://github.com/mphasize/FullDome
+ *
+ * Note: This example needs desktop-class graphics to function.
  * 
  */
  


### PR DESCRIPTION
The initCubeMap function does not work on GLES2 at least:
````
glGetError() returned the following error codes after a call to glTexParameteri(<int> 0x8513, <int> 0x8072, <int> 0x812F): GL_INVALID_ENUM ( 1280 0x500)
glGetError() returned the following error codes after a call to glTexImage2D(<int> 0x8515, <int> 0x0, <int> 0x8058, <int> 0x400, <int> 0x400, <int> 0x0, <int> 0x1908, <int> 0x1401, <java.nio.Buffer> null): GL_INVALID_VALUE ( 1281 0x501)
````