### PR TITLE
Add 64-bit ARM detection to install-arm script

### DIFF
--- a/content/static/download.html
+++ b/content/static/download.html
@@ -16,7 +16,8 @@
         <a href="http://download.processing.org/processing-3.3.1-windows32.zip">Windows</a> 32-bit</li>
         <li><a href="http://download.processing.org/processing-3.3.1-linux64.tgz">Linux</a> 64-bit<br />
         <a href="http://download.processing.org/processing-3.3.1-linux32.tgz">Linux</a> 32-bit<br />
-        <a href="http://download.processing.org/processing-3.3.1-linux-armv6hf.tgz">Linux</a> ARMv6hf</li>
+        <a href="http://download.processing.org/processing-3.3.1-linux-armv6hf.tgz">Linux</a> ARMv6hf<br />
+        <a href="http://download.processing.org/processing-3.3.1-linux-arm64.tgz">Linux</a> ARM64<br /></li>
         <li><a href="http://download.processing.org/processing-3.3.1-macosx.zip">Mac OS X</a></li>
 
       </ul>
@@ -48,6 +49,7 @@
         <a href="http://download.processing.org/processing-3.3.1-linux32.tgz">Linux 32</a> 
         <a href="http://download.processing.org/processing-3.3.1-linux64.tgz">Linux 64</a>
         <a href="http://download.processing.org/processing-3.3.1-linux-armv6hf.tgz">Linux ARMv6hf</a>
+        <a href="http://download.processing.org/processing-3.3.1-linux-arm64.tgz">Linux ARM64</a>
         <a href="http://download.processing.org/processing-3.3.1-macosx.zip">Mac OS X</a> 
       </li>
       <li>

--- a/download/install-arm.sh
+++ b/download/install-arm.sh
@@ -3,15 +3,22 @@
 # This script installs the latest version of Processing for ARM into /usr/local/lib
 # Run it like this: "curl https://processing.org/download/install-arm.sh | sudo sh"
 
-# this assumes that newer releases are at the top
-TAR="$(curl -sL https://api.github.com/repos/processing/processing/releases | grep -oh -m 1 'https.*linux-armv6hf.tgz')"
+# check if on a 64-bit operating system
+if [[ $(file $(which file)) == *aarch64* ]]
+then
+  FLAVOR="arm64"
+  TAR="$(curl -sL https://api.github.com/repos/processing/processing/releases | grep -oh -m 1 'https.*linux-arm64.tgz')"
+else
+  FLAVOR="armv6hf"
+  TAR="$(curl -sL https://api.github.com/repos/processing/processing/releases | grep -oh -m 1 'https.*linux-armv6hf.tgz')"
+fi
 
 echo "\nDownloading $TAR..."
-curl -L $TAR > processing-linux-armv6hf-latest.tgz
+curl -L $TAR > processing-linux-$FLAVOR-latest.tgz
 
 echo "Installing in /usr/local..."
-tar fx processing-linux-armv6hf-latest.tgz -C /usr/local/lib
-rm -f processing-linux-armv6hf-latest.tgz
+tar fx processing-linux-$FLAVOR-latest.tgz -C /usr/local/lib
+rm -f processing-linux-$FLAVOR-latest.tgz
 
 # this returns the highest version installed
 VER="$(basename $(ls -dvr /usr/local/lib/processing-* | head -1))"


### PR DESCRIPTION
This should go in once https://github.com/processing/processing/pull/5002 lands in a released version.

(At that point, content/static/download.html will also want to be updated to include the download link to the "ARM64" version.)