### PR TITLE
Remove redundant call to noStroke

### DIFF
--- a/content/examples/Basics/Math/Sine/Sine.pde
+++ b/content/examples/Basics/Math/Sine/Sine.pde
@@ -11,7 +11,6 @@ void setup() {
   size(640, 360);
   diameter = height - 10;
   noStroke();
-  noStroke();
   fill(255, 204, 0);
 }
 


### PR DESCRIPTION
The `Basics/Math/Sine` example was calling `noStroke` twice.