### PR TITLE
Add quad() to corresponding functions in PShape

### DIFF
--- a/content/api_en/createShape.xml
+++ b/content/api_en/createShape.xml
@@ -111,7 +111,7 @@ void draw() {
 
 
 <description><![CDATA[
-The <b>createShape()</b> function is used to define a new shape. Once created, this shape can be drawn with the <b>shape()</b> function. The basic way to use the function defines new primitive shapes. One of the following parameters are used as the first parameter: <b>ELLIPSE</b>, <b>RECT</b>, <b>ARC</b>, <b>TRIANGLE</b>, <b>SPHERE</b>, <b>BOX</b>, <b>QUAD</b>, or <b>LINE</b>. The parameters for each of these different shapes are the same as their corresponding functions: <b>ellipse()</b>, <b>rect()</b>, <b>arc()</b>, <b>triangle()</b>, <b>sphere()</b>, <b>box()</b>, and <b>line()</b>. The first example above clarifies how this works.<br />
+The <b>createShape()</b> function is used to define a new shape. Once created, this shape can be drawn with the <b>shape()</b> function. The basic way to use the function defines new primitive shapes. One of the following parameters are used as the first parameter: <b>ELLIPSE</b>, <b>RECT</b>, <b>ARC</b>, <b>TRIANGLE</b>, <b>SPHERE</b>, <b>BOX</b>, <b>QUAD</b>, or <b>LINE</b>. The parameters for each of these different shapes are the same as their corresponding functions: <b>ellipse()</b>, <b>rect()</b>, <b>arc()</b>, <b>triangle()</b>, <b>sphere()</b>, <b>box()</b>, <b>quad()</b>, and <b>line()</b>. The first example above clarifies how this works.<br />
 <br />
 Custom, unique shapes can be made by using <b>createShape()</b> without a parameter. After the shape is started, the drawing attributes and geometry can be set directly to the shape within the <b>beginShape()</b> and <b>endShape()</b> methods. See the second example above for specifics, and the reference for <b>beginShape()</b> for all of its options.<br />
 <br />


### PR DESCRIPTION
The list of functions corresponding to PShape parameters did not include `quad()`. It appeared to be an oversight and this corrects it.