### PR TITLE
Add a line about exporting in Eclipse

### DIFF
--- a/content/static/tutorials/eclipse/index.html
+++ b/content/static/tutorials/eclipse/index.html
@@ -235,6 +235,8 @@ public class Stripe {
 }</pre>
 <p>That's all there is to it! The same process works for all the mouse, keyboard, and other event based functions.</p>
 <p>Note, however, that these functions are inherited from PApplet, thus you will only be able to use them in your client class, and not in any other object classes.</p>
+<h4>Exporting in Eclipse</h4>
+<p>You can export a project from eclipse the same way you export any project in Eclipse. For more information, visit Eclipse's documentation. <a href="https://help.eclipse.org/oxygen/topic/org.eclipse.jdt.doc.user/tasks/tasks-37.htm?cp=1_3_1_4"> How to export a runnable .jar in Eclipse</a>.</p>    
 <p class="license">This tutorial is for Processing version 3.0+. If you see any errors or have comments, please <a href="https://github.com/processing/processing-docs/issues?state=open">let us know</a>. This work is licensed under a <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.</p>
 </td>
 </tr>


### PR DESCRIPTION
Since exporting in Eclipse isn't unique with processing, seemed best to just link to Eclipse's documentation.