### PR TITLE
Added library page for SVG modeled after PDF page.

### DIFF
--- a/content/api_en/LIB_svg/index.html
+++ b/content/api_en/LIB_svg/index.html
@@ -1,0 +1,167 @@
+
+<div class="librarytitle"><h3>SVG Export</h3></div>
+
+<div class="full-alt">
+    <p>The SVG library makes it possible to write SVG files directly from Processing. These vector graphics files can be scaled to any size and output at very high resolutions. The SVG library can flatten 3D data into a 2D vector file, but to export 3D data, use the DXF library. The source code is available on the <a href="https://github.com/processing/processing/tree/master/java/libraries/svg">Processing</a> GitHub repository. Please report bugs <a href="https://github.com/processing/processing/issues">here</a>.<br />
+    <br />
+    This library can be used with the core Processing function <strong>size()</strong>, or <strong>createGraphics()</strong>. See the examples below for different techniques.</p>
+</div>
+
+<div class="full">
+<p>
+<strong>SVG Export (No Screen Display)</strong><br />
+<br />
+This example draws a single frame to a SVG file and quits. (Note that no display window will open; this helps when you're trying to create massive SVG images that are far larger than the screen size.)</p>
+
+<pre>import processing.svg.*;
+
+void setup() {
+  size(400, 400, SVG, "filename.svg");
+}
+
+void draw() {
+  // Draw something good here
+  line(0, 0, width/2, height);
+
+  // Exit the program
+  println("Finished.");
+  exit();
+}</pre>
+
+
+<p><strong>SVG Export (With Screen Display)</strong><br />
+<br />
+To draw to the screen while also saving an SVG beginRecord()
+and endRecord() functions. Unlike the PDF renderer, the SVG renderer will only save the final frame of a sequence. This is slower, but is useful when you need to
+see what you're working on as it saves.</p>
+
+<pre>import processing.svg.*;
+
+void setup() {
+  size(400, 400);
+  noLoop();
+  beginRecord(SVG, "filename.svg");
+}
+
+void draw() {
+  // Draw something good here
+  line(0, 0, width/2, height);
+
+  endRecord();
+}</pre>
+
+
+<p><strong>Single Frame from an Animation (With Screen Display)</strong><br />
+It's also possible to save one frame from a program with moving elements.
+Create a boolean variable to turn the SVG recording process on and off</p>
+
+<pre>import processing.svg.*;
+
+boolean record;
+
+void setup() {
+  size(400, 400);
+}
+
+void draw() {
+  if (record) {
+    // Note that #### will be replaced with the frame number. Fancy!
+    beginRecord(SVG, "frame-####.svg");
+  }
+
+  // Draw something good here
+  background(255);
+  line(mouseX, mouseY, width/2, height/2);
+
+  if (record) {
+    endRecord();
+	record = false;
+  }
+}
+
+// Use a keypress so thousands of files aren't created
+void mousePressed() {
+  record = true;
+}</pre>
+
+
+<p><strong>SVG Files from 3D Geometry (With Screen Display)</strong><br />
+<br />
+To create vectors from 3D data, use the beginRaw() and endRaw() commands.
+These commands will grab the shape data just before it is rendered to the screen.
+At this stage, your entire scene is nothing but a long list of lines and triangles.
+This means that a shape created with sphere() method will be made up of hundreds of
+triangles, rather than a single object.</p>
+
+<p>When using beginRaw() and endRaw(), it's possible to write to either a 2D or 3D renderer.
+For instance, beginRaw() with the SVG library will write the geometry as flattened triangles
+and lines.</p>
+
+<pre>import processing.svg.*;
+
+boolean record;
+
+void setup() {
+  size(500, 500, P3D);
+}
+
+void draw() {
+  if (record) {
+    beginRaw(SVG, "output.svg");
+  }
+
+  // Do all your drawing here
+  background(204);
+  translate(width/2, height/2, -200);
+  rotateZ(0.2);
+  rotateY(mouseX/500.0);
+  box(200);
+
+  if (record) {
+    endRaw();
+    record = false;
+  }
+}
+
+// Hit 'r' to record a single frame
+void keyPressed() {
+  if (key == 'r') {
+    record = true;
+  }
+}
+</pre>
+
+<p><strong>Using createGraphics() to Create an SVG File</strong><br />
+<br />
+To write a SVG file using only the createGraphics() command, rather than as
+part of a sketch, it's necessary to call dispose() on the PGraphicsSVG object.
+This is the same as calling exit(), but it won't quit the sketch.</p>
+
+<pre>import processing.svg.*;
+
+PGraphics svg = createGraphics(300, 300, SVG, "output.svg");
+svg.beginDraw();
+svg.background(128, 0, 0);
+svg.line(50, 50, 250, 250);
+svg.dispose();
+svg.endDraw();</pre>
+
+
+<p>
+<strong>Additional notes for the SVG renderer:</strong>
+
+<ul>
+
+<li>If you want 3D data, use the DXF recording library instead.
+
+<li>Using hint(ENABLE_DEPTH_SORT) can improve the appearance of 3D geometry drawn to 2D file formats.
+
+<li>Many methods, particularly pixel-based methods, don't make sense for SVG renderers. This includes: loadPixels, updatePixels, get, set, mask, filter, copy, blend, save, and image
+
+<li> Again, exit() is really important when using SVG with size().
+
+</UL>
+
+</p>
+
+</div>

--- a/content/api_en/libraries/index.html
+++ b/content/api_en/libraries/index.html
@@ -16,7 +16,12 @@
 		<h5><a href="net/index.html">Network</a></h5>
     	<p>Send and receive data over the Internet through simple clients and servers.</p>
     </li>
-	
+
+	<li>
+		<h5><a href="svg/index.html">SVG Export</a></h5>
+		<p>Create SVG files.</p>
+	</li>
+
     <li>
     	<h5><a href="serial/index.html">Serial</a></h5>
     	<p>Send data between Processing and external hardware through serial communication (RS-232).</p>

--- a/generate/libraries.php
+++ b/generate/libraries.php
@@ -19,7 +19,7 @@ $where = CONTENTDIR . 'static/';
 //`cd $path && /usr/bin/git pull https://github.com/processing/processing-docs/`;
 
 
-$libraries = array('net', 'serial', 'video', 'dxf', 'pdf', 'sound', 'io');
+$libraries = array('net', 'serial', 'video', 'dxf', 'pdf', 'sound', 'io', 'svg');
 $lib_dir = REFERENCEDIR.'libraries/';
 
 // Create Index
@@ -47,7 +47,7 @@ foreach ($libraries as $lib) {
 
     // template and copy index
     $index = CONTENTDIR.$source.'/index.html';
-    if($lib == 'pdf' || $lib == 'dxf') {
+    if($lib == 'pdf' || $lib == 'dxf' || $lib == 'svg') {
 	  //$page = new Page(strtoupper($lib) . ' \\ Libraries', 'Libraries', 'Library-index');
 	  $page = new Page(strtoupper($lib) . ' \\ Libraries', 'Libraries');
 	} else {

--- a/generate/libraries_local.php
+++ b/generate/libraries_local.php
@@ -8,7 +8,7 @@ require_once('./contributions.php');
 $benchmark_start = microtime_float();
 
 
-$libraries = array('net', 'serial', 'video', 'dxf', 'pdf', 'sound', 'io');
+$libraries = array('net', 'serial', 'video', 'dxf', 'pdf', 'sound', 'io', 'svg');
 $lib_dir = DISTDIR.'libraries';
 
 


### PR DESCRIPTION
addresses issue #406.

Sample code in the Library page is included in the following repo: https://github.com/quinkennedy/processing-svg-examples