### PR TITLE
Rectifying graph for mouseX signal

### DIFF
--- a/content/examples/Basics/Input/MouseSignals/MouseSignals.pde
+++ b/content/examples/Basics/Input/MouseSignals/MouseSignals.pde
@@ -46,7 +46,7 @@ void draw()
 
   for(int i=1; i<width; i++) {
     stroke(255);
-    point(i, xvals[i]/3);
+    point(i, map(xvals[i],0,width,0,height/3-1));
     stroke(0);
     point(i, height/3+yvals[i]/3);
     stroke(255);


### PR DESCRIPTION
The mouseX signal is not properly drawn on the graph, xvals[i] is simply divided by 3 like in the case for mouseY, which is not the case, but instead, it should be mapped from "width" to "height/3" .
Hence the line 49: point(i, map(xvals[i],0,width,0,height/3-1));