### PR TITLE
Add unbinary int signature

### DIFF
--- a/content/api_en/unbinary.xml
+++ b/content/api_en/unbinary.xml
@@ -17,11 +17,20 @@ String s3 = "00000100";
 println(unbinary(s1));  // Prints "16"
 println(unbinary(s2));  // Prints "8"
 println(unbinary(s3));  // Prints "4"
+
+int i1 = 10000;
+int i2 = 1000;
+int i3 = 100
+println(unbinary(i1));  // Prints "16"
+println(unbinary(i2));  // Prints "8"
+println(unbinary(i3));  // Prints "4"
 ]]></code>
 </example>
 
 <description><![CDATA[
 Converts a <b>String</b> representation of a binary number to its equivalent integer value. For example, <b>unbinary("00001000")</b> will return <b>8</b>.
+
+Alternately, converts an <b>int</b> representation of a binary number to its equivalent integer value. For example, <b>unbinary(1000)</b> will return <b>8</b>.
 ]]></description>
 
 </root>


### PR DESCRIPTION
Documentation for unbinary PR processing/processing#5681

Accepts an integer that uses decimal format to represent a sequence of bits, and returns an integer in native format.

For example, the integer 1101 represents binary, and returns 13 (binary 0b1101, or 8+4+0+1 = 13). 

This signature extends unbinary(String value). It is a workaround for lack of parser support for binary literals such as 0b1101.
