### PR TITLE
Fix typo in RadialGradient documentation page

### DIFF
--- a/content/examples/Basics/Color/RadialGradient/RadialGradient.pde
+++ b/content/examples/Basics/Color/RadialGradient/RadialGradient.pde
@@ -1,7 +1,7 @@
 /**
  * Radial Gradient. 
  * 
- * Draws are series of concentric circles to create a gradient 
+ * Draws a series of concentric circles to create a gradient 
  * from one color to another.
  */
 

--- a/content/examples_p5/Basics/Color/RadialGradient/RadialGradient.js
+++ b/content/examples_p5/Basics/Color/RadialGradient/RadialGradient.js
@@ -1,7 +1,7 @@
 /**
  * Radial Gradient. 
  * 
- * Draws are series of concentric circles to create a gradient 
+ * Draws a series of concentric circles to create a gradient 
  * from one color to another.
  */
 


### PR DESCRIPTION
Typo in a comment in RadialGradient that shows on the documentation page. Bug also found in p5js code even though it doesn't show up in the documentation on the web.
Fix for issue #722 