### PR TITLE
Temporarily patch the broken download links for the 3.5.3 (0269) release.

### DIFF
--- a/content/static/download.html
+++ b/content/static/download.html
@@ -12,14 +12,16 @@
       <span class="version">3.5.3</span>
       <span class="version-date">(3 February 2019)</span>
       <ul class="current-downloads">
-        <li><a href="http://download.processing.org/processing-3.5.3-windows64.zip">Windows</a> 64-bit<br />
-        <a href="http://download.processing.org/processing-3.5.3-windows32.zip">Windows</a> 32-bit</li>
-        <li><a href="http://download.processing.org/processing-3.5.3-linux64.tgz">Linux</a> 64-bit<br />
-        <a href="http://download.processing.org/processing-3.5.3-linux32.tgz">Linux</a> 32-bit<br />
+        <li><a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-windows64.zip">Windows</a> 64-bit<br />
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-windows32.zip">Windows</a> 32-bit</li>
+        <li><a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux64.tgz">Linux</a> 64-bit<br />
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux32.tgz">Linux</a> 32-bit<br />
+<!--
         <a href="http://download.processing.org/processing-3.5.3-linux-armv6hf.tgz">Linux</a> ARM<br>
+-->
         (<a href="http://pi.processing.org/" style="font-size: inherit;">running on Pi?</a>)
         </li>
-        <li><a href="http://download.processing.org/processing-3.5.3-macosx.zip">Mac OS X</a></li>
+        <li><a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-macosx.zip">Mac OS X</a></li>
       </ul>
     </div>
 
@@ -43,12 +45,14 @@
     <li>
         <span class="version">3.5.3</span>
         <span class="version-date">(3 February 2019)</span>
-        <a href="http://download.processing.org/processing-3.5.3-windows32.zip">Win 32</a>
-        <a href="http://download.processing.org/processing-3.5.3-windows64.zip">Win 64</a>
-        <a href="http://download.processing.org/processing-3.5.3-linux32.tgz">Linux 32</a>
-        <a href="http://download.processing.org/processing-3.5.3-linux64.tgz">Linux 64</a>
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-windows32.zip">Win 32</a>
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-windows64.zip">Win 64</a>
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux32.tgz">Linux 32</a>
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-linux64.tgz">Linux 64</a>
+<!--
         <a href="http://download.processing.org/processing-3.5.3-linux-armv6hf.tgz">Linux ARMv6hf</a>
-        <a href="http://download.processing.org/processing-3.5.3-macosx.zip">Mac OS X</a>
+-->
+        <a href="https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-macosx.zip">Mac OS X</a>
     </li>
     <!--
     <li>


### PR DESCRIPTION
As stated in #742 (and also #[5782 ](https://github.com/processing/processing/issues/5782)and #[5783 ](https://github.com/processing/processing/issues/5783)on processing/processing), the redirections are slightly broken:
`http://download.processing.org/processing-3.5.3-*` redirects to:
`https://github.com/processing/processing/releases/download/processing-0266-3.5/processing-3.5.3-*` instead of:
`https://github.com/processing/processing/releases/download/processing-0269-3.5.3/processing-3.5.3-*`

_This patch may serve as a fast temporary workaround just in case patching the redirections on download.processing.org requires more time because of permissions or something. Once patched on the redirection server, it is better to revert this PR, so as to keep the maintainability of the Processing download page._