### PR TITLE
fixed encoding of character on sketch 4A of electronics tutorial

### DIFF
--- a/content/static/tutorials/electronics/index.html
+++ b/content/static/tutorials/electronics/index.html
@@ -635,7 +635,7 @@ boolean mouseOverRect() {        // Test if mouse is over square
 <pre>
 // Read data from the serial port and set the position of a servomotor 
 // according to the value
-#include <Servo.h>
+#include &lt;Servo.h&gt;
 
 Servo myservo;                   // Create servo object to control a servo
 int servoPin = 3;                // Connect yellow servo wire to digital I/O pin 3 (must be PWM) 


### PR DESCRIPTION
changed the "<" and ">" characters for their HTML entities. Related to #496  