### PR TITLE
Brightness example: Fix maximum value for brightness

### DIFF
--- a/content/examples/Basics/Color/Brightness/Brightness.pde
+++ b/content/examples/Basics/Color/Brightness/Brightness.pde
@@ -11,7 +11,7 @@ int lastBar = -1;
 
 void setup() {
   size(640, 360);
-  colorMode(HSB, width, 100, width);
+  colorMode(HSB, width, 100, height);
   noStroke();
   background(0);
 }


### PR DESCRIPTION
**Issue**
The colors in the color brightness example always seem to be rather dark. Even when moving the cursor to the lowest position possible.

**Reason**
The maximum value for brightness is being set to the `width` of the canvas. As `mouseY` is being used as the brightness of the color and the height of the canvas is much lower than the width, it is impossible to reach full brightness for a bar.

**Fix**
This can be fixed by setting the maximum value for brightness to the `height` of the canvas.