### PR TITLE
Add Rosetta Code example set

### DIFF
--- a/contrib_generate/sources.conf
+++ b/contrib_generate/sources.conf
@@ -1,4 +1,4 @@
-# Next ID: 249
+# Next ID: 250
 # Increment after assigning ID to new contribution
 
 [Library : 3D]
@@ -296,6 +296,7 @@
 194 \ http://damellis.github.io/wovns-processing-examples/WOVNS.txt
 226 \ https://github.com/Apress/processing-for-android/releases/download/latest/processing-for-android-examples.txt
 243 \ https://coding-creative.dringtech.com/examples/coding-creative-examples.txt
+249 \ https://github.com/jeremydouglass/processing_rosetta_examples/releases/latest/download/processing_rosetta_examples.txt
 
 [Tool : ]
 020 \ https://dl.dropboxusercontent.com/u/69944346/ColorSelectorPlus/ColorSelectorPlusTool.txt


### PR DESCRIPTION
Adds the PDE Processing Rosetta Code example set to Contributions Manager.
https://github.com/jeremydouglass/processing_rosetta_examples
