### PR TITLE
Document strokeWeight(1) + invisible point() problem, workarounds

### DIFF
--- a/content/api_en/point.xml
+++ b/content/api_en/point.xml
@@ -38,7 +38,7 @@ Use <b>stroke()</b> to set the color of a <b>point()</b>.
 <br /><br />
 Point appears round with the default <b>strokeCap(ROUND)</b> and square with <b>strokeCap(PROJECT)</b>. Points are invisible with <b>strokeCap(SQUARE)</b> (no cap).
 <br /><br />
-Using point() with strokeWeight(1) or smaller may draw nothing to the screen, depending on the graphics settings of the computer. Workarounds include setting the pixel use <b>set()</s> or draw the point using either <b>circle()</b> or <b>square()</b>.
+Using point() with strokeWeight(1) or smaller may draw nothing to the screen, depending on the graphics settings of the computer. Workarounds include setting the pixel using <b>set()</s> or drawing the point using either <b>circle()</b> or <b>square()</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/point.xml
+++ b/content/api_en/point.xml
@@ -37,6 +37,8 @@ Draws a point, a coordinate in space at the dimension of one pixel. The first pa
 Use <b>stroke()</b> to set the color of a <b>point()</b>.
 <br /><br />
 Point appears round with the default <b>strokeCap(ROUND)</b> and square with <b>strokeCap(PROJECT)</b>. Points are invisible with <b>strokeCap(SQUARE)</b> (no cap).
+<br /><br />
+Using point() with strokeWeight(1) or smaller may draw nothing to the screen, depending on the graphics settings of the computer. Workarounds include setting the pixel use <b>set()</s> or draw the point using either <b>circle()</b> or <b>square()</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/strokeWeight.xml
+++ b/content/api_en/strokeWeight.xml
@@ -22,6 +22,8 @@ line(20, 70, 80, 70);
 
 <description><![CDATA[
 Sets the width of the stroke used for lines, points, and the border around shapes. All widths are set in units of pixels.
+<br /><br />
+Using point() with strokeWeight(1) or smaller may draw nothing to the screen, depending on the graphics settings of the computer. Workarounds include setting the pixel use <b>set()</s> or draw the point using either <b>circle()</b> or <b>square()</b>.
 ]]></description>
 
 </root>

--- a/content/api_en/strokeWeight.xml
+++ b/content/api_en/strokeWeight.xml
@@ -23,7 +23,7 @@ line(20, 70, 80, 70);
 <description><![CDATA[
 Sets the width of the stroke used for lines, points, and the border around shapes. All widths are set in units of pixels.
 <br /><br />
-Using point() with strokeWeight(1) or smaller may draw nothing to the screen, depending on the graphics settings of the computer. Workarounds include setting the pixel use <b>set()</s> or draw the point using either <b>circle()</b> or <b>square()</b>.
+Using point() with strokeWeight(1) or smaller may draw nothing to the screen, depending on the graphics settings of the computer. Workarounds include setting the pixel using <b>set()</s> or drawing the point using either <b>circle()</b> or <b>square()</b>.
 ]]></description>
 
 </root>


### PR DESCRIPTION
As per Ben Fry suggestion:

https://github.com/processing/processing/issues/5957#issuecomment-575353739

> Using point() with small strokeWeight(1) or smaller may not draw anything to the screen, depending on the graphics settings on your computer. To fix this, you can 1) use set() instead, 2) use a larger strokeWeight(), or 3) draw the point using circle() or square() instead.