### PR TITLE
doccomment drops outdated ref to index.html generation

### DIFF
--- a/content/api_en/include/doccomment.xml
+++ b/content/api_en/include/doccomment.xml
@@ -22,7 +22,9 @@ line(50, 0, 50, 100);
 </example>
 
 <description><![CDATA[
-Explanatory notes embedded within the code and written to the "index.html" file created when the code is exported. Doc comments (documentation comments) are used for sharing a description of your sketch when the program is exported. Export the code by hitting the "Export" button on the Toolbar.
+Explanatory notes embedded within the code. Doc comments (documentation comments) are used to describe and document your sketch, classes, and methods. Comments are ignored by the compiler.
+<br><br>
+Doc comments may be converted into browseable documentation using external editors and tools such as the command line javadoc, doc generators such as Doxygen, or IDEs such as Eclipse, Netbeans, or IntelliJ IDEA.
 ]]></description>
 
 <syntax>

--- a/content/api_en/include/multilinecomment.xml
+++ b/content/api_en/include/multilinecomment.xml
@@ -22,7 +22,7 @@ line(50, 0, 50, 100);
 </example>
 
 <description><![CDATA[
-Explanatory notes embedded within the code. Comments are used to remind yourself and to inform others about the function of your program. Multiline comments are used for large text descriptions of code or to comment out chunks of code while debugging applications. Comments are ignored by the compiler
+Explanatory notes embedded within the code. Comments are used to remind yourself and to inform others about the function of your program. Multiline comments are used for large text descriptions of code or to comment out chunks of code while debugging applications. Comments are ignored by the compiler.
 ]]></description>
 
 <syntax>


### PR DESCRIPTION
and adds line on how to do javadoc generation with third-party tools.

closes #796