### PR TITLE
HTTPRequests Library download URL change

### DIFF
--- a/contrib_generate/sources.conf
+++ b/contrib_generate/sources.conf
@@ -67,7 +67,7 @@
 #404# 128 \ http://dasmithii.com/GNet.txt
 133 \ https://raw.githubusercontent.com/nok/redis-processing/master/download/Redis.txt
 135 \ https://temboo.com/files/temboo-processing.txt
-137 \ http://shiffman.net/p5/libraries/httprequests_processing/httprequests_processing.txt
+137 \ https://github.com/runemadsen/HTTP-Requests-for-Processing/releases/download/latest/httprequests_processing.txt
 144 \ http://unfoldingmaps.org/Unfolding.txt
 175 \ https://github.com/alexandrainst/processing_websockets/releases/download/latest/webSockets.txt
 183 \ https://github.com/onlylemi/processing-android-capture/releases/download/latest/AndroidCaptureForProcessing.txt


### PR DESCRIPTION
@prisonerjohn I'm working on releasing a new version of the HTTPRequests-for-Processing library and I think it makes more sense to point to the "latest" tag on github? Is this the correct way to do so? cc @runemadsen 